### PR TITLE
Fix code and strong elements in MDN summary being backwards.

### DIFF
--- a/src/bot/commands/docs/mdn.ts
+++ b/src/bot/commands/docs/mdn.ts
@@ -42,12 +42,13 @@ export default class MDNCommand extends Command {
 			filter: 'a',
 			replacement: (text: string, node: { href: string }) => `[${text}](https://developer.mozilla.org${node.href})`
 		});
+		const summary = body.Summary.replace(/<code><strong>(.+)<\/strong><\/code>/g, '<strong><code>$1<\/code><\/strong>');
 		const embed = new MessageEmbed()
 			.setColor(0x066FAD)
 			.setAuthor('MDN', 'https://i.imgur.com/DFGXabG.png', 'https://developer.mozilla.org/')
 			.setURL(`https://developer.mozilla.org${body.URL}`)
 			.setTitle(body.Title)
-			.setDescription(turndown.turndown(body.Summary));
+			.setDescription(turndown.turndown(summary));
 
 		return message.util!.send(embed);
 	}


### PR DESCRIPTION
This is a simple change using `String#replace` to reverse the `<code>` and `<strong>` elements of MDN summaries in order to properly display them in Markdown when passed through Turndown. It'll stop `**this syntax**` and make it the **`prettier version`**.