### PR TITLE
fix(Emoji): Unicode escape sequences

### DIFF
--- a/src/bot/commands/info/emoji.ts
+++ b/src/bot/commands/info/emoji.ts
@@ -60,7 +60,7 @@ export default class EmojiInfoCommand extends Command {
 				stripIndents`
 				• Name: \`${emoji.key}\`
 				• Raw: \`${emoji.emoji}\`
-				• Unicode: \`${punycode.ucs2.decode(emoji.emoji).map((e: any) => `\\u${e.toString(16).toUpperCase()}`).join('')}\`
+				• Unicode: \`${punycode.ucs2.decode(emoji.emoji).map((e: any) => `\\u${e.toString(16).toUpperCase().padStart(4, '0')}`).join('')}\`
 				`
 			);
 		}


### PR DESCRIPTION
Some ucs2 decoded, hex encoded characters are only 2 characters long. This ensures that they get padded with 0's in order to be valid Unicode escape sequences.