### PR TITLE
Include 11.4-dev in docs command

### DIFF
--- a/src/bot/commands/docs/docs.ts
+++ b/src/bot/commands/docs/docs.ts
@@ -3,7 +3,8 @@ import { Message, TextChannel } from 'discord.js';
 import fetch from 'node-fetch';
 import * as qs from 'querystring';
 
-const SOURCES = ['stable', 'master', 'rpc', 'commando', 'akairo', 'akairo-master'];
+const DEFAULTSOURCES = ['stable', 'master', 'rpc', 'commando', 'akairo', 'akairo-master'];
+const EXTENDEDSOURCES = ['11.4-dev', '11.4.2', '11.3.2', '11.2.0', '11.1.0', '11.0.0', '10.0.1', '9.3.1', '9.2.0', '9.1.1', '9.0.2'];
 
 export default class DocsCommand extends Command {
 	public constructor() {
@@ -37,7 +38,12 @@ export default class DocsCommand extends Command {
 
 	public async exec(message: Message, { query, force }: { query: string; force: boolean }): Promise<Message | Message[]> {
 		const q = query.split(' ');
-		const source = SOURCES.includes(q.slice(-1)[0]) ? q.pop() : 'stable';
+		const sourceString = query.slice(-1)[0];
+		const isExtendedSource = EXTENDEDSOURCES.includes(sourceString);
+		let source = DEFAULTSOURCES.includes(sourceString) || isExtendedSource ? query.pop() : 'stable';
+		if (isExtendedSource) {
+			source = `https://raw.githubusercontent.com/discordjs/discord.js/docs/${source}.json`;
+		}
 		const queryString = qs.stringify({ src: source, q: q.join(' '), force });
 		const res = await fetch(`https://djsdocs.sorta.moe/v2/embed?${queryString}`);
 		const embed = await res.json();

--- a/src/bot/commands/docs/docs.ts
+++ b/src/bot/commands/docs/docs.ts
@@ -3,8 +3,7 @@ import { Message, TextChannel } from 'discord.js';
 import fetch from 'node-fetch';
 import * as qs from 'querystring';
 
-const DEFAULTSOURCES = ['stable', 'master', 'rpc', 'commando', 'akairo', 'akairo-master'];
-const EXTENDEDSOURCES = ['11.4-dev', '11.4.2', '11.3.2', '11.2.0', '11.1.0', '11.0.0', '10.0.1', '9.3.1', '9.2.0', '9.1.1', '9.0.2'];
+const SOURCES = ['stable', 'master', 'rpc', 'commando', 'akairo', 'akairo-master', '11.4-dev'];
 
 export default class DocsCommand extends Command {
 	public constructor() {
@@ -38,10 +37,8 @@ export default class DocsCommand extends Command {
 
 	public async exec(message: Message, { query, force }: { query: string; force: boolean }): Promise<Message | Message[]> {
 		const q = query.split(' ');
-		const sourceString = query.slice(-1)[0];
-		const isExtendedSource = EXTENDEDSOURCES.includes(sourceString);
-		let source = DEFAULTSOURCES.includes(sourceString) || isExtendedSource ? query.pop() : 'stable';
-		if (isExtendedSource) {
+		let source = SOURCES.includes(q.slice(-1)[0]) ? q.pop() : 'stable';
+		if (source === '11.4-dev') {
 			source = `https://raw.githubusercontent.com/discordjs/discord.js/docs/${source}.json`;
 		}
 		const queryString = qs.stringify({ src: source, q: q.join(' '), force });


### PR DESCRIPTION
~~Some versions do not have aliases set by the docs API so the URL to the libraries JSON docs file has to be  provided to the query.   
This PR support for these discord.js versions.~~

Edit: only includes 11.4-dev after feedback