### PR TITLE
chore(deps): Bump veza from 0.5.0 to 0.6.0

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -34,10 +34,10 @@ async function main(): Promise<void> {
 
 	const node = await new Node('api')
 		.on('error', (error, client) => console.error(`> IPC error from ${client.name}`, error))
-		.on('client.disconnect', client => console.log(`> IPC client diconnected: ${client.name}`))
-		.on('client.destroy', client => console.log(`> IPC client destroyed: ${client.name}`))
-		.on('client.ready', client => console.log(`> IPC connected to: ${client.name}`))
-		.connectTo('bot', 9512);
+		.on('socket.disconnect', client => console.log(`> IPC client diconnected: ${client.name}`))
+		.on('socket.destroy', client => console.log(`> IPC client destroyed: ${client.name}`))
+		.on('socket.ready', client => console.log(`> IPC connected to: ${client.name}`))
+		.connectTo(9512);
 
 	const schema = await buildSchema({
 		resolvers: [OAuthUserResolver, GuildResolver, GuildSettingsResolver, TagResolver]

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -23,7 +23,7 @@
 		"polka": "^0.5.2",
 		"reflect-metadata": "^0.1.13",
 		"type-graphql": "^0.17.4",
-		"veza": "^0.5.1"
+		"veza": "^0.6.0"
 	},
 	"devDependencies": {
 		"@types/cookie": "^0.3.3",

--- a/src/bot/client/YukikazeClient.ts
+++ b/src/bot/client/YukikazeClient.ts
@@ -247,7 +247,7 @@ export default class YukikazeClient extends AkairoClient {
 		await this.db.connect();
 		this.node = await new Node('bot')
 			.on('error', (error, client) => this.logger.error(`[IPC] Error from ${client.name}`, error))
-			.on('client.identify', client => this.logger.info(`[IPC] Client connected: ${client.name}`))
+			.on('client.ready', client => this.logger.info(`[IPC] Client connected: ${client.name}`))
 			.on('client.destroy', client => this.logger.info(`[IPC] Client destroyed: ${client.name}`))
 			.serve(9512);
 		this.settings = new TypeORMProvider(this.db.getRepository(Setting));

--- a/src/bot/package.json
+++ b/src/bot/package.json
@@ -31,7 +31,7 @@
 		"reflect-metadata": "^0.1.13",
 		"turndown": "^5.0.3",
 		"typeorm": "^0.2.18",
-		"veza": "^0.5.1",
+		"veza": "^0.6.0",
 		"winston": "^3.2.1",
 		"winston-daily-rotate-file": "^3.9.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,6 +2525,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
+binarytf@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/binarytf/-/binarytf-1.0.0.tgz#dcf339922fa286511fa8603e2d5ef8e4483eb623"
+  integrity sha512-H2b3ax8maE7AilKMAA0mSHECHWn1aEIgmiMsUcAVfseZ49pPZsVxRiwMyi3CqGyQQ9Syyg2UZXIc3TSaU2ohdA==
+
 bintrees@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
@@ -4000,13 +4005,13 @@ discord.js@discordjs/discord.js:
   version "12.0.0-dev"
   resolved "https://codeload.github.com/discordjs/discord.js/tar.gz/1bec28bd8105aa09f43492491be9dd9cc7f7d701"
   dependencies:
-    form-data "^2.3.3"
-    node-fetch "^2.3.0"
-    pako "^1.0.8"
-    prism-media "^1.0.0"
+    form-data "^2.3.2"
+    node-fetch "^2.1.2"
+    pako "^1.0.0"
+    prism-media amishshah/prism-media
     setimmediate "^1.0.5"
-    tweetnacl "^1.0.1"
-    ws "^6.1.3"
+    tweetnacl "^1.0.0"
+    ws "^6.0.0"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -10787,10 +10792,12 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-veza@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/veza/-/veza-0.5.1.tgz#a4f326b7ec8326b3c0ef37c222cb0ce2d1ff4a77"
-  integrity sha512-MrqMS+z9YAIw6lb6GK+kus9SpWWuwEymVwhlbbko5o5rMHS9myRmqgAYL1JqmHVm4QONDXVQx4TRXrJfYSLllQ==
+veza@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/veza/-/veza-0.6.0.tgz#d19fbfe85d143d0a6ae0cd3f7665ea59bb57062f"
+  integrity sha512-TKRn0m6xk+pYIGPD6mlq3fnLESnHzgMntkxg5/Vc/W0n60GmzrYfNYd0lirVNSvYTT8TEXlABTUd+rxfxy0mAQ==
+  dependencies:
+    binarytf "1.0.0"
 
 vinyl-fs@^3.0.0, vinyl-fs@^3.0.3:
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4005,13 +4005,13 @@ discord.js@discordjs/discord.js:
   version "12.0.0-dev"
   resolved "https://codeload.github.com/discordjs/discord.js/tar.gz/1bec28bd8105aa09f43492491be9dd9cc7f7d701"
   dependencies:
-    form-data "^2.3.2"
-    node-fetch "^2.1.2"
-    pako "^1.0.0"
-    prism-media amishshah/prism-media
+    form-data "^2.3.3"
+    node-fetch "^2.3.0"
+    pako "^1.0.8"
+    prism-media "^1.0.0"
     setimmediate "^1.0.5"
-    tweetnacl "^1.0.0"
-    ws "^6.0.0"
+    tweetnacl "^1.0.1"
+    ws "^6.1.3"
 
 doctrine@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
And fixed all the breaking changes I could find, I don't know how to properly test this repository, so all honesty, this is untested.