### PR TITLE
Reduce minimum timer to 3m

### DIFF
--- a/src/bot/commands/reminders/add.ts
+++ b/src/bot/commands/reminders/add.ts
@@ -22,7 +22,7 @@ export default class ReminderAddCommand extends Command {
 					type: (_, str): number | null => {
 						if (!str) return null;
 						const duration = ms(str);
-						if (duration && duration >= 300000 && !isNaN(duration)) return duration;
+						if (duration && duration >= 180000 && !isNaN(duration)) return duration;
 						return null;
 					},
 					prompt: {


### PR DESCRIPTION
Earl Grey tea is best enjoyed at 3-4 minutes to avoid bitterness.
Previously i had to slightly over-steep my beloved tea due to the 5 minute minimum timer