### PR TITLE
Remove unnecessary ts-ignores 

### DIFF
--- a/src/bot/commands/config/config.ts
+++ b/src/bot/commands/config/config.ts
@@ -1,4 +1,4 @@
-import { Command, Flag } from 'discord-akairo';
+import { Command, Flag, PrefixSupplier } from 'discord-akairo';
 import { Message } from 'discord.js';
 import { stripIndents } from 'common-tags';
 
@@ -43,8 +43,7 @@ export default class ConfigCommand extends Command {
 				['config-clear', 'clear']
 			],
 			otherwise: (msg: Message): string => {
-				// @ts-ignore
-				const prefix = this.handler.prefix(msg);
+				const prefix = (this.handler.prefix as PrefixSupplier)(msg);
 				return stripIndents`
 					When you beg me so much I just can't not help you~
 					Check \`${prefix}help config\` for more information.

--- a/src/bot/commands/config/delete.ts
+++ b/src/bot/commands/config/delete.ts
@@ -1,4 +1,4 @@
-import { Command, Flag } from 'discord-akairo';
+import { Command, Flag, PrefixSupplier } from 'discord-akairo';
 import { Message } from 'discord.js';
 import { stripIndents } from 'common-tags';
 
@@ -27,8 +27,7 @@ export default class DeleteConfigCommand extends Command {
 				['config-del-restrict', 'restrictRoles', 'restrict', 'restrict-roles']
 			],
 			otherwise: (msg: Message): string => {
-				// @ts-ignore
-				const prefix = this.handler.prefix(msg);
+				const prefix = (this.handler.prefix as PrefixSupplier)(msg);
 				return stripIndents`
 					When you beg me so much I just can't not help you~
 					Check \`${prefix}help config\` for more information.

--- a/src/bot/commands/config/set-restrict.ts
+++ b/src/bot/commands/config/set-restrict.ts
@@ -1,4 +1,4 @@
-import { Command, Flag } from 'discord-akairo';
+import { Command, Flag, PrefixSupplier } from 'discord-akairo';
 import { Message } from 'discord.js';
 import { stripIndent } from 'common-tags';
 
@@ -25,8 +25,7 @@ export default class SetConfigRestrictRolesCommand extends Command {
 				['config-set-restrict-tag', 'tag']
 			],
 			otherwise: (msg: Message): string => {
-				// @ts-ignore
-				const prefix = this.handler.prefix(msg);
+				const prefix = (this.handler.prefix as PrefixSupplier)(msg);
 				return stripIndent`
 					When you beg me so much I just can't not help you~
 					Check \`${prefix}help config\` for more information.

--- a/src/bot/commands/config/set.ts
+++ b/src/bot/commands/config/set.ts
@@ -1,4 +1,4 @@
-import { Command, Flag } from 'discord-akairo';
+import { Command, Flag, PrefixSupplier } from 'discord-akairo';
 import { Message } from 'discord.js';
 import { stripIndents } from 'common-tags';
 
@@ -27,8 +27,7 @@ export default class SetConfigCommand extends Command {
 				['config-set-restrict', 'restrictRoles', 'restrict', 'restrict-roles']
 			],
 			otherwise: (msg: Message): string => {
-				// @ts-ignore
-				const prefix = this.handler.prefix(msg);
+				const prefix = (this.handler.prefix as PrefixSupplier)(msg);
 				return stripIndents`
 					When you beg me so much I just can't not help you~
 					Check \`${prefix}help config\` for more information.

--- a/src/bot/commands/config/toggle.ts
+++ b/src/bot/commands/config/toggle.ts
@@ -1,4 +1,4 @@
-import { Command, Flag } from 'discord-akairo';
+import { Command, Flag, PrefixSupplier } from 'discord-akairo';
 import { Message } from 'discord.js';
 import { stripIndents } from 'common-tags';
 
@@ -33,8 +33,7 @@ export default class ToggleCommand extends Command {
 				['toggle-token-filtering', 'tokenfiltering', 'token']
 			],
 			otherwise: (msg: Message): string => {
-				// @ts-ignore
-				const prefix = this.handler.prefix(msg);
+				const prefix = (this.handler.prefix as PrefixSupplier)(msg);
 				return stripIndents`
 					When you beg me so much I just can't not help you~
 					Check \`${prefix}help toggle\` for more information.

--- a/src/bot/commands/mod/ban.ts
+++ b/src/bot/commands/mod/ban.ts
@@ -1,4 +1,4 @@
-import { Argument, Command } from 'discord-akairo';
+import { Argument, Command, PrefixSupplier } from 'discord-akairo';
 import { Message, GuildMember, TextChannel, User } from 'discord.js';
 import { stripIndents } from 'common-tags';
 import Util from '../../util';
@@ -125,8 +125,7 @@ export default class BanCommand extends Command {
 		this.client.settings.set(message.guild!, 'caseTotal', totalCases);
 
 		if (!reason) {
-			// @ts-ignore
-			const prefix = this.handler.prefix(message);
+			const prefix = (this.handler.prefix as PrefixSupplier)(message);
 			reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 		}
 

--- a/src/bot/commands/mod/cases.ts
+++ b/src/bot/commands/mod/cases.ts
@@ -1,4 +1,4 @@
-import { Command, Flag } from 'discord-akairo';
+import { Command, Flag, PrefixSupplier } from 'discord-akairo';
 import { Message } from 'discord.js';
 import { stripIndents } from 'common-tags';
 
@@ -36,8 +36,7 @@ export default class CasesCommand extends Command {
 				['case-delete', 'delete', 'del', 'remove', 'rm']
 			],
 			otherwise: (msg: Message): string => {
-				// @ts-ignore
-				const prefix = this.handler.prefix(msg);
+				const prefix = (this.handler.prefix as PrefixSupplier)(msg);
 				return stripIndents`
 					When you beg me so much I just can't not help you~
 					Check \`${prefix}help cases\` for more information.

--- a/src/bot/commands/mod/embed.ts
+++ b/src/bot/commands/mod/embed.ts
@@ -1,4 +1,4 @@
-import { Command } from 'discord-akairo';
+import { Command, PrefixSupplier } from 'discord-akairo';
 import { Message, GuildMember, TextChannel } from 'discord.js';
 import Util from '../../util';
 import { Case } from '../../models/Cases';
@@ -75,8 +75,7 @@ export default class RestrictEmbedCommand extends Command {
 		this.client.settings.set(message.guild!, 'caseTotal', totalCases);
 
 		if (!reason) {
-			// @ts-ignore
-			const prefix = this.handler.prefix(message);
+			const prefix = (this.handler.prefix as PrefixSupplier)(message);
 			reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 		}
 

--- a/src/bot/commands/mod/emoji.ts
+++ b/src/bot/commands/mod/emoji.ts
@@ -1,4 +1,4 @@
-import { Command } from 'discord-akairo';
+import { Command, PrefixSupplier } from 'discord-akairo';
 import { Message, GuildMember, TextChannel } from 'discord.js';
 import Util from '../../util';
 import { Case } from '../../models/Cases';
@@ -75,8 +75,7 @@ export default class RestrictEmojiCommand extends Command {
 		this.client.settings.set(message.guild!, 'caseTotal', totalCases);
 
 		if (!reason) {
-			// @ts-ignore
-			const prefix = this.handler.prefix(message);
+			const prefix = (this.handler.prefix as PrefixSupplier)(message);
 			reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 		}
 

--- a/src/bot/commands/mod/kick.ts
+++ b/src/bot/commands/mod/kick.ts
@@ -1,4 +1,4 @@
-import { Command } from 'discord-akairo';
+import { Command, PrefixSupplier } from 'discord-akairo';
 import { Message, GuildMember, TextChannel } from 'discord.js';
 import { stripIndents } from 'common-tags';
 import Util from '../../util';
@@ -77,8 +77,7 @@ export default class KickCommand extends Command {
 		this.client.settings.set(message.guild!, 'caseTotal', totalCases);
 
 		if (!reason) {
-			// @ts-ignore
-			const prefix = this.handler.prefix(message);
+			const prefix = (this.handler.prefix as PrefixSupplier)(message);
 			reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 		}
 

--- a/src/bot/commands/mod/mute.ts
+++ b/src/bot/commands/mod/mute.ts
@@ -1,4 +1,4 @@
-import { Command } from 'discord-akairo';
+import { Command, PrefixSupplier } from 'discord-akairo';
 import { Message, GuildMember, TextChannel } from 'discord.js';
 import Util from '../../util';
 import { Case } from '../../models/Cases';
@@ -91,8 +91,7 @@ export default class MuteCommand extends Command {
 		this.client.settings.set(message.guild!, 'caseTotal', totalCases);
 
 		if (!reason) {
-			// @ts-ignore
-			const prefix = this.handler.prefix(message);
+			const prefix = (this.handler.prefix as PrefixSupplier)(message);
 			reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 		}
 

--- a/src/bot/commands/mod/reaction.ts
+++ b/src/bot/commands/mod/reaction.ts
@@ -1,4 +1,4 @@
-import { Command } from 'discord-akairo';
+import { Command, PrefixSupplier } from 'discord-akairo';
 import { Message, GuildMember, TextChannel } from 'discord.js';
 import Util from '../../util';
 import { Case } from '../../models/Cases';
@@ -75,8 +75,7 @@ export default class RestrictReactionCommand extends Command {
 		this.client.settings.set(message.guild!, 'caseTotal', totalCases);
 
 		if (!reason) {
-			// @ts-ignore
-			const prefix = this.handler.prefix(message);
+			const prefix = (this.handler.prefix as PrefixSupplier)(message);
 			reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 		}
 

--- a/src/bot/commands/mod/restrict.ts
+++ b/src/bot/commands/mod/restrict.ts
@@ -1,4 +1,4 @@
-import { Command, Flag } from 'discord-akairo';
+import { Command, Flag, PrefixSupplier } from 'discord-akairo';
 import { Message } from 'discord.js';
 import { stripIndents } from 'common-tags';
 
@@ -56,8 +56,7 @@ export default class RestrictCommand extends Command {
 				['restrict-tag', 'tag']
 			],
 			otherwise: (msg: Message): string => {
-				// @ts-ignore
-				const prefix = this.handler.prefix(msg);
+				const prefix = (this.handler.prefix as PrefixSupplier)(msg);
 				return stripIndents`
 					When you beg me so much I just can't not help you~
 					Check \`${prefix}help config\` for more information.

--- a/src/bot/commands/mod/softban.ts
+++ b/src/bot/commands/mod/softban.ts
@@ -1,4 +1,4 @@
-import { Command } from 'discord-akairo';
+import { Command, PrefixSupplier } from 'discord-akairo';
 import { Message, GuildMember, TextChannel } from 'discord.js';
 import { stripIndents } from 'common-tags';
 import Util from '../../util';
@@ -95,8 +95,7 @@ export default class SoftbanCommand extends Command {
 		this.client.settings.set(message.guild!, 'caseTotal', totalCases);
 
 		if (!reason) {
-			// @ts-ignore
-			const prefix = this.handler.prefix(message);
+			const prefix = (this.handler.prefix as PrefixSupplier)(message);
 			reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 		}
 

--- a/src/bot/commands/mod/tag.ts
+++ b/src/bot/commands/mod/tag.ts
@@ -1,4 +1,4 @@
-import { Command } from 'discord-akairo';
+import { Command, PrefixSupplier } from 'discord-akairo';
 import { Message, GuildMember, TextChannel } from 'discord.js';
 import Util from '../../util';
 import { Case } from '../../models/Cases';
@@ -75,8 +75,7 @@ export default class RestrictTagCommand extends Command {
 		this.client.settings.set(message.guild!, 'caseTotal', totalCases);
 
 		if (!reason) {
-			// @ts-ignore
-			const prefix = this.handler.prefix(message);
+			const prefix = (this.handler.prefix as PrefixSupplier)(message);
 			reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 		}
 

--- a/src/bot/commands/mod/unban.ts
+++ b/src/bot/commands/mod/unban.ts
@@ -1,4 +1,4 @@
-import { Command } from 'discord-akairo';
+import { Command, PrefixSupplier } from 'discord-akairo';
 import { Message, User, TextChannel } from 'discord.js';
 import Util from '../../util';
 import { Case } from '../../models/Cases';
@@ -73,8 +73,7 @@ export default class UnbanCommand extends Command {
 		this.client.settings.set(message.guild!, 'caseTotal', totalCases);
 
 		if (!reason) {
-			// @ts-ignore
-			const prefix = this.handler.prefix(message);
+			const prefix = (this.handler.prefix as PrefixSupplier)(message);
 			reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 		}
 

--- a/src/bot/commands/mod/warn.ts
+++ b/src/bot/commands/mod/warn.ts
@@ -1,4 +1,4 @@
-import { Command } from 'discord-akairo';
+import { Command, PrefixSupplier } from 'discord-akairo';
 import { Message, GuildMember, TextChannel } from 'discord.js';
 import Util from '../../util';
 import { Case } from '../../models/Cases';
@@ -60,8 +60,7 @@ export default class WarnCommand extends Command {
 		this.client.settings.set(message.guild!, 'caseTotal', totalCases);
 
 		if (!reason) {
-			// @ts-ignore
-			const prefix = this.handler.prefix(message);
+			const prefix = (this.handler.prefix as PrefixSupplier)(message);
 			reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 		}
 

--- a/src/bot/commands/reminders/reminder.ts
+++ b/src/bot/commands/reminders/reminder.ts
@@ -1,4 +1,4 @@
-import { Command } from 'discord-akairo';
+import { Command, PrefixSupplier } from 'discord-akairo';
 import { Message } from 'discord.js';
 import { stripIndents } from 'common-tags';
 
@@ -43,8 +43,7 @@ export default class ReminderCommand extends Command {
 
 	public async exec(message: Message, { method, name }: { method: string; name: string }): Promise<Message | Message[] | boolean | null> {
 		if (!method) {
-			// @ts-ignore
-			const prefix = this.handler.prefix(message);
+			const prefix = (this.handler.prefix as PrefixSupplier)(message);
 			return message.util!.send(stripIndents`
 				When you beg me so much I just can't not help you~
 				Check \`${prefix}help reminder\` for more information.

--- a/src/bot/commands/tags/tag.ts
+++ b/src/bot/commands/tags/tag.ts
@@ -1,4 +1,4 @@
-import { Command, Flag } from 'discord-akairo';
+import { Command, Flag, PrefixSupplier } from 'discord-akairo';
 import { Message } from 'discord.js';
 import { stripIndents } from 'common-tags';
 
@@ -64,8 +64,7 @@ export default class TagCommand extends Command {
 				['tag-download', 'download', 'dl']
 			],
 			otherwise: (msg: Message): string => {
-				// @ts-ignore
-				const prefix = this.handler.prefix(msg);
+				const prefix = (this.handler.prefix as PrefixSupplier)(msg);
 				return stripIndents`
 					When you beg me so much I just can't not help you~
 					Check \`${prefix}help tag\` for more information.

--- a/src/bot/commands/util/help.ts
+++ b/src/bot/commands/util/help.ts
@@ -1,4 +1,4 @@
-import { Command } from 'discord-akairo';
+import { Command, PrefixSupplier } from 'discord-akairo';
 import { Message, MessageEmbed } from 'discord.js';
 import { stripIndents } from 'common-tags';
 
@@ -23,8 +23,7 @@ export default class HelpCommand extends Command {
 	}
 
 	public async exec(message: Message, { command }: { command: Command }): Promise<Message | Message[]> {
-		// @ts-ignore
-		const prefix = this.handler.prefix(message);
+		const prefix = (this.handler.prefix as PrefixSupplier)(message)
 		if (!command) {
 			const embed = new MessageEmbed()
 				.setColor(3447003)

--- a/src/bot/commands/util/prefix.ts
+++ b/src/bot/commands/util/prefix.ts
@@ -1,4 +1,4 @@
-import { Command } from 'discord-akairo';
+import { Command, PrefixSupplier } from 'discord-akairo';
 import { Message } from 'discord.js';
 
 export default class PrefixCommand extends Command {
@@ -24,8 +24,7 @@ export default class PrefixCommand extends Command {
 	}
 
 	public async exec(message: Message, { prefix }: { prefix: string }): Promise<Message | Message[]> {
-		// @ts-ignore
-		if (!prefix) return message.util!.send(`The current prefix for this guild is: \`${this.handler.prefix(message)}\``);
+		if (!prefix) return message.util!.send(`The current prefix for this guild is: \`${(this.handler.prefix as PrefixSupplier)(message)}\``);
 		this.client.settings.set(message.guild!, 'prefix', prefix);
 		if (prefix === process.env.COMMAND_PREFIX) {
 			return message.util!.reply(`the prefix has been reset to \`${prefix}\``);

--- a/src/bot/listeners/client/guildBanAdd.ts
+++ b/src/bot/listeners/client/guildBanAdd.ts
@@ -20,7 +20,7 @@ export default class GuildBanAddListener extends Listener {
 		const modLogChannel = this.client.settings.get(guild, 'modLogChannel', undefined);
 		let modMessage;
 		if (modLogChannel) {
-			const prefix = (this.client.commandHandler.prefix as PrefixSupplier)({ guild });
+			const prefix = (this.client.commandHandler.prefix as PrefixSupplier)({ guild } as Message);
 			const reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 			const embed = (await Util.logEmbed({ member: user, action: 'Ban', caseNum: totalCases, reason })).setColor(Util.CONSTANTS.COLORS.BAN);
 			modMessage = await (this.client.channels.get(modLogChannel) as TextChannel).send(embed) as Message;

--- a/src/bot/listeners/client/guildBanAdd.ts
+++ b/src/bot/listeners/client/guildBanAdd.ts
@@ -1,4 +1,4 @@
-import { Listener } from 'discord-akairo';
+import { Listener, PrefixSupplier } from 'discord-akairo';
 import { Message, Guild, User, TextChannel } from 'discord.js';
 import Util from '../../util';
 import { Case } from '../../models/Cases';
@@ -20,8 +20,7 @@ export default class GuildBanAddListener extends Listener {
 		const modLogChannel = this.client.settings.get(guild, 'modLogChannel', undefined);
 		let modMessage;
 		if (modLogChannel) {
-			// @ts-ignore
-			const prefix = this.client.commandHandler.prefix({ guild });
+			const prefix = (this.client.commandHandler.prefix as PrefixSupplier)({ guild });
 			const reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 			const embed = (await Util.logEmbed({ member: user, action: 'Ban', caseNum: totalCases, reason })).setColor(Util.CONSTANTS.COLORS.BAN);
 			modMessage = await (this.client.channels.get(modLogChannel) as TextChannel).send(embed) as Message;

--- a/src/bot/listeners/client/guildBanRemove.ts
+++ b/src/bot/listeners/client/guildBanRemove.ts
@@ -1,4 +1,4 @@
-import { Listener } from 'discord-akairo';
+import { Listener, PrefixSupplier } from 'discord-akairo';
 import { Message, Guild, User, TextChannel } from 'discord.js';
 import Util from '../../util';
 import { Case } from '../../models/Cases';
@@ -20,8 +20,7 @@ export default class GuildBanRemoveListener extends Listener {
 		const modLogChannel = this.client.settings.get(guild, 'modLogChannel', undefined);
 		let modMessage;
 		if (modLogChannel) {
-			// @ts-ignore
-			const prefix = this.client.commandHandler.prefix({ guild });
+			const prefix = (this.client.commandHandler.prefix as PrefixSupplier)({ guild } as Message);
 			const reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 			const embed = (await Util.logEmbed({ member: user, action: 'Unban', caseNum: totalCases, reason })).setColor(Util.CONSTANTS.COLORS.UNBAN);
 			modMessage = await (this.client.channels.get(modLogChannel) as TextChannel).send(embed) as Message;

--- a/src/bot/listeners/client/guildMemberUpdate.ts
+++ b/src/bot/listeners/client/guildMemberUpdate.ts
@@ -82,7 +82,7 @@ export default class GuildMemberUpdateModerationListener extends Listener {
 
 			let modMessage;
 			if (modLogChannel) {
-				const prefix = (this.client.commandHandler.prefix as PrefixSupplier)({ guild: newMember.guild });
+				const prefix = (this.client.commandHandler.prefix as PrefixSupplier)({ guild: newMember.guild } as Message);
 				const reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 				const color = Object.keys(Util.CONSTANTS.ACTIONS).find((key): boolean => Util.CONSTANTS.ACTIONS[key] === action)!.split(' ')[0].toUpperCase();
 				const embed = (await Util.logEmbed({ member: newMember, action: actionName, caseNum: totalCases, reason })).setColor(Util.CONSTANTS.COLORS[color]);

--- a/src/bot/listeners/client/guildMemberUpdate.ts
+++ b/src/bot/listeners/client/guildMemberUpdate.ts
@@ -1,4 +1,4 @@
-import { Listener } from 'discord-akairo';
+import { Listener, PrefixSupplier } from 'discord-akairo';
 import { Message, GuildMember, TextChannel } from 'discord.js';
 import { RoleState } from '../../models/RoleStates';
 import { Case } from '../../models/Cases';
@@ -82,8 +82,7 @@ export default class GuildMemberUpdateModerationListener extends Listener {
 
 			let modMessage;
 			if (modLogChannel) {
-				// @ts-ignore
-				const prefix = this.client.commandHandler.prefix({ guild: newMember.guild });
+				const prefix = (this.client.commandHandler.prefix as PrefixSupplier)({ guild: newMember.guild });
 				const reason = `Use \`${prefix}reason ${totalCases} <...reason>\` to set a reason for this case`;
 				const color = Object.keys(Util.CONSTANTS.ACTIONS).find((key): boolean => Util.CONSTANTS.ACTIONS[key] === action)!.split(' ')[0].toUpperCase();
 				const embed = (await Util.logEmbed({ member: newMember, action: actionName, caseNum: totalCases, reason })).setColor(Util.CONSTANTS.COLORS[color]);


### PR DESCRIPTION
Still uses `as`, which  isn't great. If you want me to do a refactor or something to remove this unsafe casting then tell me. It's better than ts-ignore though.