### PR TITLE
Add ownerOnly

### DIFF
--- a/src/bot/commands/util/blacklist.ts
+++ b/src/bot/commands/util/blacklist.ts
@@ -10,6 +10,7 @@ export default class BlacklistCommand extends Command {
 				content: MESSAGES.COMMANDS.UTIL.BLACKLIST.DESCRIPTION,
 				usage: '<user>',
 				examples: ['Crawl', '@Crawl', '81440962496172032'],
+				ownerOnly: true
 			},
 			category: 'util',
 			ownerOnly: true,

--- a/src/bot/commands/util/blacklist.ts
+++ b/src/bot/commands/util/blacklist.ts
@@ -10,7 +10,7 @@ export default class BlacklistCommand extends Command {
 				content: MESSAGES.COMMANDS.UTIL.BLACKLIST.DESCRIPTION,
 				usage: '<user>',
 				examples: ['Crawl', '@Crawl', '81440962496172032'],
-				ownerOnly: true
+				ownerOnly: true,
 			},
 			category: 'util',
 			ownerOnly: true,

--- a/src/bot/commands/util/eval.ts
+++ b/src/bot/commands/util/eval.ts
@@ -20,6 +20,7 @@ export default class EvalCommand extends Command {
 			description: {
 				content: MESSAGES.COMMANDS.UTIL.EVAL.DESCRIPTION,
 				usage: '<code>',
+				ownerOnly: true
 			},
 			category: 'util',
 			ownerOnly: true,

--- a/src/bot/commands/util/eval.ts
+++ b/src/bot/commands/util/eval.ts
@@ -20,7 +20,7 @@ export default class EvalCommand extends Command {
 			description: {
 				content: MESSAGES.COMMANDS.UTIL.EVAL.DESCRIPTION,
 				usage: '<code>',
-				ownerOnly: true
+				ownerOnly: true,
 			},
 			category: 'util',
 			ownerOnly: true,

--- a/src/bot/commands/util/help.ts
+++ b/src/bot/commands/util/help.ts
@@ -45,7 +45,7 @@ export default class HelpCommand extends Command {
 		const embed = new MessageEmbed()
 			.setColor(3447003)
 			.setTitle(`\`${command.aliases[0]} ${command.description.usage ? command.description.usage : ''}\``)
-			.addField('❯ Description', command.description.content || '\u200b');
+			.addField('❯ Description', `${command.description.content ? command.description.content : ''} ${command.description.ownerOnly ? '\n**[Owner Only]**': ''}`);
 
 		if (command.aliases.length > 1) embed.addField('❯ Aliases', `\`${command.aliases.join('` `')}\``, true);
 		if (command.description.examples && command.description.examples.length)


### PR DESCRIPTION
I added an ownerOnly boolean to the description object of owner-only commands. In the help command, I modified the description field to add `**[Owner Only]**` to the bottom of the field if the ownerOnly boolean existed and was true.