### PR TITLE
[WIP] Add templating to tags

### DIFF
--- a/src/bot/commands/tags/add.ts
+++ b/src/bot/commands/tags/add.ts
@@ -57,7 +57,7 @@ export default class TagAddCommand extends Command {
 
 	public async exec(
 		message: Message,
-		{ name, content, hoist, templated }: { name: string; content: string; hoist: boolean, templated: boolean }
+		{ name, content, hoist, templated }: { name: string; content: string; hoist: boolean; templated: boolean }
 	) {
 		if (name && name.length >= 1900) {
 			return message.util!.reply(MESSAGES.COMMANDS.TAGS.ADD.TOO_LONG);

--- a/src/bot/commands/tags/add.ts
+++ b/src/bot/commands/tags/add.ts
@@ -37,6 +37,11 @@ export default class TagAddCommand extends Command {
 					match: 'flag',
 					flag: ['--hoist', '--pin'],
 				},
+				{
+					id: 'template',
+					match: 'flag',
+					flag: ['--template'],
+				},
 			],
 		});
 	}
@@ -50,7 +55,10 @@ export default class TagAddCommand extends Command {
 		return null;
 	}
 
-	public async exec(message: Message, { name, content, hoist }: { name: string; content: string; hoist: boolean }) {
+	public async exec(
+		message: Message,
+		{ name, content, hoist, templated }: { name: string; content: string; hoist: boolean, templated: boolean }
+	) {
 		if (name && name.length >= 1900) {
 			return message.util!.reply(MESSAGES.COMMANDS.TAGS.ADD.TOO_LONG);
 		}
@@ -65,6 +73,7 @@ export default class TagAddCommand extends Command {
 				user: message.author!.id,
 				name,
 				hoisted: hoist && staffRole,
+				templated: templated && staffRole,
 				content,
 			},
 		});

--- a/src/bot/commands/tags/add.ts
+++ b/src/bot/commands/tags/add.ts
@@ -57,7 +57,7 @@ export default class TagAddCommand extends Command {
 
 	public async exec(
 		message: Message,
-		{ name, content, hoist, templated }: { name: string; content: string; hoist: boolean; templated: boolean }
+		{ name, content, hoist, templated }: { name: string; content: string; hoist: boolean; templated: boolean },
 	) {
 		if (name && name.length >= 1900) {
 			return message.util!.reply(MESSAGES.COMMANDS.TAGS.ADD.TOO_LONG);

--- a/src/bot/commands/tags/edit.ts
+++ b/src/bot/commands/tags/edit.ts
@@ -82,7 +82,7 @@ export default class TagEditCommand extends Command {
 			unhoist,
 			templated,
 			untemplated,
-			content
+			content,
 		}: { tag: Tags; hoist: boolean; unhoist: boolean; templated: boolean; untemplated: boolean; content: string },
 	) {
 		const staffRole = message.member!.roles.has(this.client.settings.get(message.guild!, SETTINGS.MOD_ROLE));

--- a/src/bot/commands/tags/edit.ts
+++ b/src/bot/commands/tags/edit.ts
@@ -76,8 +76,14 @@ export default class TagEditCommand extends Command {
 
 	public async exec(
 		message: Message,
-		{ tag, hoist, unhoist, templated, untemplated, content }:
-			{ tag: Tags; hoist: boolean; unhoist: boolean; templated: boolean; untemplated: boolean; content: string },
+		{
+			tag,
+			hoist,
+			unhoist,
+			templated,
+			untemplated,
+			content
+		}: { tag: Tags; hoist: boolean; unhoist: boolean; templated: boolean; untemplated: boolean; content: string },
 	) {
 		const staffRole = message.member!.roles.has(this.client.settings.get(message.guild!, SETTINGS.MOD_ROLE));
 		if (tag.user !== message.author!.id && !staffRole) {

--- a/src/bot/commands/tags/edit.ts
+++ b/src/bot/commands/tags/edit.ts
@@ -15,7 +15,7 @@ export default class TagEditCommand extends Command {
 			},
 			channel: 'guild',
 			ratelimit: 2,
-			flags: ['--hoist', '--pin', '--unhoist', '--unpin'],
+			flags: ['--hoist', '--pin', '--unhoist', '--unpin', '--template', '--untemplate'],
 		});
 	}
 
@@ -48,6 +48,16 @@ export default class TagEditCommand extends Command {
 			flag: ['--unhoist', '--unpin'],
 		};
 
+		const templated = yield {
+			match: 'flag',
+			flag: ['--template'],
+		};
+
+		const untemplated = yield {
+			match: 'flag',
+			flag: ['--untemplate'],
+		};
+
 		const content = yield hoist || unhoist
 			? {
 					match: 'rest',
@@ -61,12 +71,13 @@ export default class TagEditCommand extends Command {
 					},
 			  };
 
-		return { tag, hoist, unhoist, content };
+		return { tag, hoist, unhoist, templated, untemplated, content };
 	}
 
 	public async exec(
 		message: Message,
-		{ tag, hoist, unhoist, content }: { tag: Tags; hoist: boolean; unhoist: boolean; content: string },
+		{ tag, hoist, unhoist, templated, untemplated, content }:
+			{ tag: Tags; hoist: boolean; unhoist: boolean; templated: boolean; untemplated: boolean; content: string },
 	) {
 		const staffRole = message.member!.roles.has(this.client.settings.get(message.guild!, SETTINGS.MOD_ROLE));
 		if (tag.user !== message.author!.id && !staffRole) {
@@ -81,12 +92,14 @@ export default class TagEditCommand extends Command {
 			? {
 					id: tag.id,
 					hoisted: staffRole && (hoist || unhoist) ? hoist : tag.hoisted,
+					templated: staffRole && (templated || untemplated) ? templated : tag.templated,
 					content,
 					last_modified: message.author!.id,
 			  }
 			: {
 					id: tag.id,
 					hoisted: staffRole && (hoist || unhoist) ? hoist : tag.hoisted,
+					templated: staffRole && (templated || untemplated) ? templated : tag.templated,
 					last_modified: message.author!.id,
 			  };
 		await graphQLClient.mutate({

--- a/src/bot/commands/tags/show.ts
+++ b/src/bot/commands/tags/show.ts
@@ -58,7 +58,7 @@ export default class TagShowCommand extends Command {
 			const output = interpolateString(tag.content, {
 				author: message.author.toString(),
 				channel: message.channel.toString(),
-				guild: message.guild ? message.guild.toString() : null
+				guild: message.guild ? message.guild.toString() : null,
 			});
 
 			return message.util!.send(output || 'The output was empty.');

--- a/src/bot/commands/tags/show.ts
+++ b/src/bot/commands/tags/show.ts
@@ -3,6 +3,7 @@ import { Message, Util } from 'discord.js';
 import { MESSAGES, PRODUCTION, SETTINGS } from '../../util/constants';
 import { GRAPHQL, graphQLClient } from '../../util/graphQL';
 import { Tags } from '../../util/graphQLTypes';
+import { interpolateString } from '../../util/template';
 
 export default class TagShowCommand extends Command {
 	public constructor() {
@@ -52,6 +53,16 @@ export default class TagShowCommand extends Command {
 				uses: tag.uses + 1,
 			},
 		});
+
+		if (tag.templated) {
+			const output = interpolateString(tag.content, {
+				author: message.author.toString(),
+				channel: message.channel.toString(),
+				guild: message.guild ? message.guild.toString() : null
+			});
+
+			return message.util!.send(output || 'The output was empty.');
+		}
 
 		return message.util!.send(tag.content);
 	}

--- a/src/bot/util/template.ts
+++ b/src/bot/util/template.ts
@@ -1,11 +1,15 @@
-import { parse, Interpolate, Template } from "./templateParser";
+/* eslint @typescript-eslint/no-use-before-define: 0 */
 
-export function interpolateString(input: string, data: any): string {
+import { parse, Interpolate, Template } from './templateParser';
+
+type InterpolateData = { [k: string]: string };
+
+export function interpolateString(input: string, data: InterpolateData) {
     const template = parse(input);
     return interpolateTemplate(template, data);
 }
 
-function interpolateTemplate(template: Template, data: any): string {
+function interpolateTemplate(template: Template, data: InterpolateData) {
     let output = '';
     for (const segment of template) {
         if (segment.t === 'raw') {
@@ -18,9 +22,9 @@ function interpolateTemplate(template: Template, data: any): string {
     return output;
 }
 
-function interpolate(int: Interpolate, data: any): string {
+function interpolate(int: Interpolate, data: InterpolateData) {
     for (const alt of int.alts) {
-        if (Object.prototype.hasOwnProperty.call(data, alt) && data[alt] != null) {
+        if (Object.prototype.hasOwnProperty.call(data, alt) && data[alt] !== null && data[alt] !== undefined) {
             return alt;
         }
     }

--- a/src/bot/util/template.ts
+++ b/src/bot/util/template.ts
@@ -1,0 +1,211 @@
+export type Raw = { t: 'raw', value: string };
+
+export type Interpolate = { t: 'interpolate', alts: string[], def: Template | null };
+
+export type Template = (Raw | Interpolate)[];
+
+export class ParseError extends Error {
+    public readonly input: string;
+    public readonly position: number;
+
+    public constructor(message: string, input: string, position: number) {
+        super(message);
+
+        this.input = input;
+        this.position = position;
+    }
+
+    public formatted(): string {
+        const start = Math.max(this.lineBefore(), this.position - 10);
+        const end = Math.min(this.lineAfter(), this.position + 10);
+        const line = this.input.slice(start, end);
+        const offset = this.position - start;
+        return `${line}\n${'-'.repeat(offset)}^\n${this.message}`;
+    }
+
+    private lineBefore(): number {
+        const i = this.input.slice(0, this.position).lastIndexOf('\n');
+        return i === -1 ? 0 : i;
+    }
+
+    private lineAfter() {
+        const i = this.input.indexOf('\n', this.position);
+        return i === -1 ? this.input.length : i + this.position;
+    }
+}
+
+export function parse(input: string): Template {
+    return pTemplate({ input, position: 0 }, false);
+}
+
+/**
+ * EBNF:
+ * 
+ * Template    = { Segment }
+ * Segment     = Interpolate | Raw
+ * Interpolate = "${" _ Alts [ Def ] "}"
+ * Alts        = Ident _ [{ "|" _ Ident _ }]
+ * Def         = "=" _'"' Template '"' _
+ * Raw         = Escaped | Character
+ * Escaped     = "\" any char
+ * Character   = any char
+ * Ident       = alphanumeric identifier
+ * _           = any amount of whitespace
+ */
+
+type State = {
+    input: string;
+    position: number;
+};
+
+function pTemplate(s: State, q: boolean): Template {
+    const segments: (string | Raw | Interpolate)[] = [];
+    while (s.position < s.input.length && (!q || !testString(s, '"'))) {
+        const seg = pSegment(s);
+        if (segments.length > 0) {
+            const prev = segments[segments.length - 1];
+            /**
+             * To make things easier to use, we merge adjacent strings together,
+             * instead of making pRaw return a Raw, since that allocates more objects.
+             * Cases:
+             * [string] + string = [string]
+             * [raw]    + string = [raw]
+             * [interp] + string = [interp, string]
+             * [string] + interp = [raw, interp]
+             * [raw]    + interp = [raw, interp]
+             * [interp] + interp = [interp, interp]
+             */
+            if (typeof seg === 'string') {
+                if (typeof prev === 'string') {
+                    segments[segments.length - 1] += seg;
+                } else if (prev.t === 'raw') {
+                    prev.value += seg;
+                } else {
+                    segments.push(seg);
+                }
+            } else {
+                if (typeof prev === 'string') {
+                    segments[segments.length - 1] = { t: 'raw', value: prev };
+                    segments.push(seg);
+                } else {
+                    segments.push(seg);
+                }
+            }
+        } else {
+            segments.push(seg);
+        }
+    }
+
+    if (segments.length > 0) {
+        const prev = segments[segments.length - 1];
+        if (typeof prev === 'string') {
+            segments[segments.length - 1] = { t: 'raw', value: prev };
+        }
+    }
+
+    if (s.position != s.input.length) {
+        throw new ParseError('Not enough input', s.input, s.position);
+    }
+
+    return segments as Template;
+}
+
+function pSegment(s: State): string | Interpolate {
+    if (testString(s, '${')) {
+        return pInterpolate(s);
+    }
+
+    return pRaw(s);
+}
+
+function pInterpolate(s: State): Interpolate {
+    pString(s, '${');
+    p_(s);
+    const alts = pAlts(s);
+    let def = null;
+    if (testString(s, '=')) {
+        def = pDef(s);
+    }
+
+    pString(s, '}');
+    return { t: 'interpolate', alts, def };
+}
+
+function pAlts(s: State): string[] {
+    const idents = [];
+    idents.push(pIdent(s));
+    p_(s);
+    while (testString(s, '|')) {
+        pString(s, '|');
+        p_(s);
+        idents.push(pIdent(s));
+        p_(s);
+    }
+
+    return idents;
+}
+
+function pDef(s: State): Template {
+    pString(s, '=');
+    p_(s);
+    pString(s, '"');
+    const x = pTemplate(s, true);
+    pString(s, '"');
+    p_(s);
+    return x;
+}
+
+function pRaw(s: State): string {
+    return testString(s, '\\') ? pEscaped(s) : pCharacter(s);
+}
+
+function pEscaped(s: State): string {
+    const match = matchRegex(s, /^\\(.)/);
+    if (match === null) {
+        throw new ParseError('Expected an escape character', s.input, s.position);
+    }
+
+    s.position += match[0].length;
+    return match[1];
+}
+
+function pCharacter(s: State): string {
+    if (s.position >= s.input.length) {
+        throw new ParseError('Unexpected end of input', s.input, s.position);
+    }
+
+    s.position++;
+    return s.input[s.position - 1];
+}
+
+function pIdent(s: State): string {
+    const match = matchRegex(s, /^[A-Za-z0-9]+/);
+    if (match === null) {
+        throw new ParseError('Expected a valid identifier made of alphanumeric characters', s.input, s.position);
+    }
+
+    const ident = match[0];
+    s.position += ident.length;
+    return ident;
+}
+
+function p_(s: State): void {
+    const match = matchRegex(s, /^\s*/);
+    s.position += match![0].length;
+}
+
+function pString(s: State, x: string): void {
+    if (testString(s, x)) {
+        s.position += x.length;
+    } else {
+        throw new ParseError(`Expected token ${x} but got ${s.input[s.position] || 'unexpected end of input'}`, s.input, s.position);
+    }
+}
+
+function testString(s: State, x: string): boolean {
+    return s.input.startsWith(x, s.position);
+}
+
+function matchRegex(s: State, r: RegExp): RegExpMatchArray | null {
+    return s.input.slice(s.position).match(r);
+}

--- a/src/bot/util/template.ts
+++ b/src/bot/util/template.ts
@@ -1,41 +1,48 @@
-export type Raw = { t: 'raw', value: string };
+export interface Raw {
+	t: 'raw';
+	value: string;
+}
 
-export type Interpolate = { t: 'interpolate', alts: string[], def: Template | null };
+export interface Interpolate {
+	t: 'interpolate';
+	alts: string[];
+	def: Template | null;
+}
 
 export type Template = (Raw | Interpolate)[];
 
 export class ParseError extends Error {
-    public readonly input: string;
-    public readonly position: number;
+	public readonly input: string;
+	public readonly position: number;
 
-    public constructor(message: string, input: string, position: number) {
-        super(message);
+	public constructor(message: string, input: string, position: number) {
+		super(message);
 
-        this.input = input;
-        this.position = position;
-    }
+		this.input = input;
+		this.position = position;
+	}
 
-    public formatted(): string {
-        const start = Math.max(this.lineBefore(), this.position - 10);
-        const end = Math.min(this.lineAfter(), this.position + 10);
-        const line = this.input.slice(start, end);
-        const offset = this.position - start;
-        return `${line}\n${'-'.repeat(offset)}^\n${this.message}`;
-    }
+	public formatted(): string {
+		const start = Math.max(this.lineBefore(), this.position - 10);
+		const end = Math.min(this.lineAfter(), this.position + 10);
+		const line = this.input.slice(start, end);
+		const offset = this.position - start;
+		return `${line}\n${'-'.repeat(offset)}^\n${this.message}`;
+	}
 
-    private lineBefore(): number {
-        const i = this.input.slice(0, this.position).lastIndexOf('\n');
-        return i === -1 ? 0 : i;
-    }
+	private lineBefore(): number {
+		const i = this.input.slice(0, this.position).lastIndexOf('\n');
+		return i === -1 ? 0 : i;
+	}
 
-    private lineAfter() {
-        const i = this.input.indexOf('\n', this.position);
-        return i === -1 ? this.input.length : i + this.position;
-    }
+	private lineAfter() {
+		const i = this.input.indexOf('\n', this.position);
+		return i === -1 ? this.input.length : i + this.position;
+	}
 }
 
 export function parse(input: string): Template {
-    return pTemplate({ input, position: 0 }, false);
+	return pTemplate({ input, position: 0 }, false);
 }
 
 /**
@@ -54,158 +61,158 @@ export function parse(input: string): Template {
  */
 
 type State = {
-    input: string;
-    position: number;
+	input: string;
+	position: number;
 };
 
 function pTemplate(s: State, q: boolean): Template {
-    const segments: (string | Raw | Interpolate)[] = [];
-    while (s.position < s.input.length && (!q || !testString(s, '"'))) {
-        const seg = pSegment(s);
-        if (segments.length > 0) {
-            const prev = segments[segments.length - 1];
-            /**
-             * To make things easier to use, we merge adjacent strings together,
-             * instead of making pRaw return a Raw, since that allocates more objects.
-             * Cases:
-             * [string] + string = [string]
-             * [raw]    + string = [raw]
-             * [interp] + string = [interp, string]
-             * [string] + interp = [raw, interp]
-             * [raw]    + interp = [raw, interp]
-             * [interp] + interp = [interp, interp]
-             */
-            if (typeof seg === 'string') {
-                if (typeof prev === 'string') {
-                    segments[segments.length - 1] += seg;
-                } else if (prev.t === 'raw') {
-                    prev.value += seg;
-                } else {
-                    segments.push(seg);
-                }
-            } else {
-                if (typeof prev === 'string') {
-                    segments[segments.length - 1] = { t: 'raw', value: prev };
-                    segments.push(seg);
-                } else {
-                    segments.push(seg);
-                }
-            }
-        } else {
-            segments.push(seg);
-        }
-    }
+	const segments: (string | Raw | Interpolate)[] = [];
+	while (s.position < s.input.length && (!q || !testString(s, '"'))) {
+		const seg = pSegment(s);
+		if (segments.length > 0) {
+			const prev = segments[segments.length - 1];
+			/**
+			 * To make things easier to use, we merge adjacent strings together,
+			 * instead of making pRaw return a Raw, since that allocates more objects.
+			 * Cases:
+			 * [string] + string = [string]
+			 * [raw]    + string = [raw]
+			 * [interp] + string = [interp, string]
+			 * [string] + interp = [raw, interp]
+			 * [raw]    + interp = [raw, interp]
+			 * [interp] + interp = [interp, interp]
+			 */
+			if (typeof seg === 'string') {
+				if (typeof prev === 'string') {
+					segments[segments.length - 1] += seg;
+				} else if (prev.t === 'raw') {
+					prev.value += seg;
+				} else {
+					segments.push(seg);
+				}
+			} else {
+				if (typeof prev === 'string') {
+					segments[segments.length - 1] = { t: 'raw', value: prev };
+					segments.push(seg);
+				} else {
+					segments.push(seg);
+				}
+			}
+		} else {
+			segments.push(seg);
+		}
+	}
 
-    if (segments.length > 0) {
-        const prev = segments[segments.length - 1];
-        if (typeof prev === 'string') {
-            segments[segments.length - 1] = { t: 'raw', value: prev };
-        }
-    }
+	if (segments.length > 0) {
+		const prev = segments[segments.length - 1];
+		if (typeof prev === 'string') {
+			segments[segments.length - 1] = { t: 'raw', value: prev };
+		}
+	}
 
-    if (s.position != s.input.length) {
-        throw new ParseError('Not enough input', s.input, s.position);
-    }
+	if (s.position != s.input.length) {
+		throw new ParseError('Not enough input', s.input, s.position);
+	}
 
-    return segments as Template;
+	return segments as Template;
 }
 
 function pSegment(s: State): string | Interpolate {
-    if (testString(s, '${')) {
-        return pInterpolate(s);
-    }
+	if (testString(s, '${')) {
+		return pInterpolate(s);
+	}
 
-    return pRaw(s);
+	return pRaw(s);
 }
 
 function pInterpolate(s: State): Interpolate {
-    pString(s, '${');
-    p_(s);
-    const alts = pAlts(s);
-    let def = null;
-    if (testString(s, '=')) {
-        def = pDef(s);
-    }
+	pString(s, '${');
+	p_(s);
+	const alts = pAlts(s);
+	let def = null;
+	if (testString(s, '=')) {
+		def = pDef(s);
+	}
 
-    pString(s, '}');
-    return { t: 'interpolate', alts, def };
+	pString(s, '}');
+	return { t: 'interpolate', alts, def };
 }
 
 function pAlts(s: State): string[] {
-    const idents = [];
-    idents.push(pIdent(s));
-    p_(s);
-    while (testString(s, '|')) {
-        pString(s, '|');
-        p_(s);
-        idents.push(pIdent(s));
-        p_(s);
-    }
+	const idents = [];
+	idents.push(pIdent(s));
+	p_(s);
+	while (testString(s, '|')) {
+		pString(s, '|');
+		p_(s);
+		idents.push(pIdent(s));
+		p_(s);
+	}
 
-    return idents;
+	return idents;
 }
 
 function pDef(s: State): Template {
-    pString(s, '=');
-    p_(s);
-    pString(s, '"');
-    const x = pTemplate(s, true);
-    pString(s, '"');
-    p_(s);
-    return x;
+	pString(s, '=');
+	p_(s);
+	pString(s, '"');
+	const x = pTemplate(s, true);
+	pString(s, '"');
+	p_(s);
+	return x;
 }
 
 function pRaw(s: State): string {
-    return testString(s, '\\') ? pEscaped(s) : pCharacter(s);
+	return testString(s, '\\') ? pEscaped(s) : pCharacter(s);
 }
 
 function pEscaped(s: State): string {
-    const match = matchRegex(s, /^\\(.)/);
-    if (match === null) {
-        throw new ParseError('Expected an escape character', s.input, s.position);
-    }
+	const match = matchRegex(s, /^\\(.)/);
+	if (match === null) {
+		throw new ParseError('Expected an escape character', s.input, s.position);
+	}
 
-    s.position += match[0].length;
-    return match[1];
+	s.position += match[0].length;
+	return match[1];
 }
 
 function pCharacter(s: State): string {
-    if (s.position >= s.input.length) {
-        throw new ParseError('Unexpected end of input', s.input, s.position);
-    }
+	if (s.position >= s.input.length) {
+		throw new ParseError('Unexpected end of input', s.input, s.position);
+	}
 
-    s.position++;
-    return s.input[s.position - 1];
+	s.position++;
+	return s.input[s.position - 1];
 }
 
 function pIdent(s: State): string {
-    const match = matchRegex(s, /^[A-Za-z0-9]+/);
-    if (match === null) {
-        throw new ParseError('Expected a valid identifier made of alphanumeric characters', s.input, s.position);
-    }
+	const match = matchRegex(s, /^[A-Za-z0-9]+/);
+	if (match === null) {
+		throw new ParseError('Expected a valid identifier made of alphanumeric characters', s.input, s.position);
+	}
 
-    const ident = match[0];
-    s.position += ident.length;
-    return ident;
+	const ident = match[0];
+	s.position += ident.length;
+	return ident;
 }
 
 function p_(s: State): void {
-    const match = matchRegex(s, /^\s*/);
-    s.position += match![0].length;
+	const match = matchRegex(s, /^\s*/);
+	s.position += match![0].length;
 }
 
 function pString(s: State, x: string): void {
-    if (testString(s, x)) {
-        s.position += x.length;
-    } else {
-        throw new ParseError(`Expected token ${x} but got ${s.input[s.position] || 'unexpected end of input'}`, s.input, s.position);
-    }
+	if (testString(s, x)) {
+		s.position += x.length;
+	} else {
+		throw new ParseError(`Expected token ${x} but got ${s.input[s.position] || 'unexpected end of input'}`, s.input, s.position);
+	}
 }
 
 function testString(s: State, x: string): boolean {
-    return s.input.startsWith(x, s.position);
+	return s.input.startsWith(x, s.position);
 }
 
 function matchRegex(s: State, r: RegExp): RegExpMatchArray | null {
-    return s.input.slice(s.position).match(r);
+	return s.input.slice(s.position).match(r);
 }

--- a/src/bot/util/template.ts
+++ b/src/bot/util/template.ts
@@ -47,7 +47,7 @@ export function parse(input: string): Template {
 
 /**
  * EBNF:
- * 
+ *
  * Template    = { Segment }
  * Segment     = Interpolate | Raw
  * Interpolate = "${" _ Alts [ Def ] "}"
@@ -60,10 +60,10 @@ export function parse(input: string): Template {
  * _           = any amount of whitespace
  */
 
-type State = {
+interface State {
 	input: string;
 	position: number;
-};
+}
 
 function pTemplate(s: State, q: boolean): Template {
 	const segments: (string | Raw | Interpolate)[] = [];
@@ -90,13 +90,11 @@ function pTemplate(s: State, q: boolean): Template {
 				} else {
 					segments.push(seg);
 				}
+			} else if (typeof prev === 'string') {
+				segments[segments.length - 1] = { t: 'raw', value: prev };
+				segments.push(seg);
 			} else {
-				if (typeof prev === 'string') {
-					segments[segments.length - 1] = { t: 'raw', value: prev };
-					segments.push(seg);
-				} else {
-					segments.push(seg);
-				}
+				segments.push(seg);
 			}
 		} else {
 			segments.push(seg);
@@ -110,7 +108,7 @@ function pTemplate(s: State, q: boolean): Template {
 		}
 	}
 
-	if (s.position != s.input.length) {
+	if (s.position !== s.input.length) {
 		throw new ParseError('Not enough input', s.input, s.position);
 	}
 
@@ -205,7 +203,11 @@ function pString(s: State, x: string): void {
 	if (testString(s, x)) {
 		s.position += x.length;
 	} else {
-		throw new ParseError(`Expected token ${x} but got ${s.input[s.position] || 'unexpected end of input'}`, s.input, s.position);
+		throw new ParseError(
+			`Expected token ${x} but got ${s.input[s.position] || 'unexpected end of input'}`,
+			s.input,
+			s.position
+		);
 	}
 }
 
@@ -214,5 +216,5 @@ function testString(s: State, x: string): boolean {
 }
 
 function matchRegex(s: State, r: RegExp): RegExpMatchArray | null {
-	return s.input.slice(s.position).match(r);
+	return r.exec(s.input.slice(s.position));
 }

--- a/src/bot/util/template.ts
+++ b/src/bot/util/template.ts
@@ -1,3 +1,5 @@
+/* eslint @typescript-eslint/no-use-before-define: 0 */
+
 export interface Raw {
 	t: 'raw';
 	value: string;
@@ -206,7 +208,7 @@ function pString(s: State, x: string): void {
 		throw new ParseError(
 			`Expected token ${x} but got ${s.input[s.position] || 'unexpected end of input'}`,
 			s.input,
-			s.position
+			s.position,
 		);
 	}
 }

--- a/src/bot/util/template.ts
+++ b/src/bot/util/template.ts
@@ -37,7 +37,7 @@ export class ParseError extends Error {
 		return i === -1 ? 0 : i;
 	}
 
-	private lineAfter() {
+	private lineAfter(): number {
 		const i = this.input.indexOf('\n', this.position);
 		return i === -1 ? this.input.length : i + this.position;
 	}

--- a/src/bot/util/template.ts
+++ b/src/bot/util/template.ts
@@ -1,222 +1,29 @@
-/* eslint @typescript-eslint/no-use-before-define: 0 */
+import { parse, Interpolate, Template } from "./templateParser";
 
-export interface Raw {
-	t: 'raw';
-	value: string;
+export function interpolateString(input: string, data: any): string {
+    const template = parse(input);
+    return interpolateTemplate(template, data);
 }
 
-export interface Interpolate {
-	t: 'interpolate';
-	alts: string[];
-	def: Template | null;
+function interpolateTemplate(template: Template, data: any): string {
+    let output = '';
+    for (const segment of template) {
+        if (segment.t === 'raw') {
+            output += segment.value;
+        } else {
+            output += interpolate(segment, data);
+        }
+    }
+
+    return output;
 }
 
-export type Template = (Raw | Interpolate)[];
+function interpolate(int: Interpolate, data: any): string {
+    for (const alt of int.alts) {
+        if (Object.prototype.hasOwnProperty.call(data, alt) && data[alt] != null) {
+            return alt;
+        }
+    }
 
-export class ParseError extends Error {
-	public readonly input: string;
-	public readonly position: number;
-
-	public constructor(message: string, input: string, position: number) {
-		super(message);
-
-		this.input = input;
-		this.position = position;
-	}
-
-	public formatted(): string {
-		const start = Math.max(this.lineBefore(), this.position - 10);
-		const end = Math.min(this.lineAfter(), this.position + 10);
-		const line = this.input.slice(start, end);
-		const offset = this.position - start;
-		return `${line}\n${'-'.repeat(offset)}^\n${this.message}`;
-	}
-
-	private lineBefore(): number {
-		const i = this.input.slice(0, this.position).lastIndexOf('\n');
-		return i === -1 ? 0 : i;
-	}
-
-	private lineAfter(): number {
-		const i = this.input.indexOf('\n', this.position);
-		return i === -1 ? this.input.length : i + this.position;
-	}
-}
-
-export function parse(input: string): Template {
-	return pTemplate({ input, position: 0 }, false);
-}
-
-/**
- * EBNF:
- *
- * Template    = { Segment }
- * Segment     = Interpolate | Raw
- * Interpolate = "${" _ Alts [ Def ] "}"
- * Alts        = Ident _ [{ "|" _ Ident _ }]
- * Def         = "=" _'"' Template '"' _
- * Raw         = Escaped | Character
- * Escaped     = "\" any char
- * Character   = any char
- * Ident       = alphanumeric identifier
- * _           = any amount of whitespace
- */
-
-interface State {
-	input: string;
-	position: number;
-}
-
-function pTemplate(s: State, q: boolean): Template {
-	const segments: (string | Raw | Interpolate)[] = [];
-	while (s.position < s.input.length && (!q || !testString(s, '"'))) {
-		const seg = pSegment(s);
-		if (segments.length > 0) {
-			const prev = segments[segments.length - 1];
-			/**
-			 * To make things easier to use, we merge adjacent strings together,
-			 * instead of making pRaw return a Raw, since that allocates more objects.
-			 * Cases:
-			 * [string] + string = [string]
-			 * [raw]    + string = [raw]
-			 * [interp] + string = [interp, string]
-			 * [string] + interp = [raw, interp]
-			 * [raw]    + interp = [raw, interp]
-			 * [interp] + interp = [interp, interp]
-			 */
-			if (typeof seg === 'string') {
-				if (typeof prev === 'string') {
-					segments[segments.length - 1] += seg;
-				} else if (prev.t === 'raw') {
-					prev.value += seg;
-				} else {
-					segments.push(seg);
-				}
-			} else if (typeof prev === 'string') {
-				segments[segments.length - 1] = { t: 'raw', value: prev };
-				segments.push(seg);
-			} else {
-				segments.push(seg);
-			}
-		} else {
-			segments.push(seg);
-		}
-	}
-
-	if (segments.length > 0) {
-		const prev = segments[segments.length - 1];
-		if (typeof prev === 'string') {
-			segments[segments.length - 1] = { t: 'raw', value: prev };
-		}
-	}
-
-	if (s.position !== s.input.length) {
-		throw new ParseError('Not enough input', s.input, s.position);
-	}
-
-	return segments as Template;
-}
-
-function pSegment(s: State): string | Interpolate {
-	if (testString(s, '${')) {
-		return pInterpolate(s);
-	}
-
-	return pRaw(s);
-}
-
-function pInterpolate(s: State): Interpolate {
-	pString(s, '${');
-	p_(s);
-	const alts = pAlts(s);
-	let def = null;
-	if (testString(s, '=')) {
-		def = pDef(s);
-	}
-
-	pString(s, '}');
-	return { t: 'interpolate', alts, def };
-}
-
-function pAlts(s: State): string[] {
-	const idents = [];
-	idents.push(pIdent(s));
-	p_(s);
-	while (testString(s, '|')) {
-		pString(s, '|');
-		p_(s);
-		idents.push(pIdent(s));
-		p_(s);
-	}
-
-	return idents;
-}
-
-function pDef(s: State): Template {
-	pString(s, '=');
-	p_(s);
-	pString(s, '"');
-	const x = pTemplate(s, true);
-	pString(s, '"');
-	p_(s);
-	return x;
-}
-
-function pRaw(s: State): string {
-	return testString(s, '\\') ? pEscaped(s) : pCharacter(s);
-}
-
-function pEscaped(s: State): string {
-	const match = matchRegex(s, /^\\(.)/);
-	if (match === null) {
-		throw new ParseError('Expected an escape character', s.input, s.position);
-	}
-
-	s.position += match[0].length;
-	return match[1];
-}
-
-function pCharacter(s: State): string {
-	if (s.position >= s.input.length) {
-		throw new ParseError('Unexpected end of input', s.input, s.position);
-	}
-
-	s.position++;
-	return s.input[s.position - 1];
-}
-
-function pIdent(s: State): string {
-	const match = matchRegex(s, /^[A-Za-z0-9]+/);
-	if (match === null) {
-		throw new ParseError('Expected a valid identifier made of alphanumeric characters', s.input, s.position);
-	}
-
-	const ident = match[0];
-	s.position += ident.length;
-	return ident;
-}
-
-function p_(s: State): void {
-	const match = matchRegex(s, /^\s*/);
-	s.position += match![0].length;
-}
-
-function pString(s: State, x: string): void {
-	if (testString(s, x)) {
-		s.position += x.length;
-	} else {
-		throw new ParseError(
-			`Expected token ${x} but got ${s.input[s.position] || 'unexpected end of input'}`,
-			s.input,
-			s.position,
-		);
-	}
-}
-
-function testString(s: State, x: string): boolean {
-	return s.input.startsWith(x, s.position);
-}
-
-function matchRegex(s: State, r: RegExp): RegExpMatchArray | null {
-	return r.exec(s.input.slice(s.position));
+    return int.def ? interpolateTemplate(int.def, data) : '';
 }

--- a/src/bot/util/template.ts
+++ b/src/bot/util/template.ts
@@ -2,32 +2,34 @@
 
 import { parse, Interpolate, Template } from './templateParser';
 
-type InterpolateData = { [k: string]: string };
+interface InterpolateData {
+	[k: string]: string;
+}
 
 export function interpolateString(input: string, data: InterpolateData) {
-    const template = parse(input);
-    return interpolateTemplate(template, data);
+	const template = parse(input);
+	return interpolateTemplate(template, data);
 }
 
 function interpolateTemplate(template: Template, data: InterpolateData) {
-    let output = '';
-    for (const segment of template) {
-        if (segment.t === 'raw') {
-            output += segment.value;
-        } else {
-            output += interpolate(segment, data);
-        }
-    }
+	let output = '';
+	for (const segment of template) {
+		if (segment.t === 'raw') {
+			output += segment.value;
+		} else {
+			output += interpolate(segment, data);
+		}
+	}
 
-    return output;
+	return output;
 }
 
 function interpolate(int: Interpolate, data: InterpolateData) {
-    for (const alt of int.alts) {
-        if (Object.prototype.hasOwnProperty.call(data, alt) && data[alt] !== null && data[alt] !== undefined) {
-            return alt;
-        }
-    }
+	for (const alt of int.alts) {
+		if (Object.prototype.hasOwnProperty.call(data, alt) && data[alt] !== null && data[alt] !== undefined) {
+			return alt;
+		}
+	}
 
-    return int.def ? interpolateTemplate(int.def, data) : '';
+	return int.def ? interpolateTemplate(int.def, data) : '';
 }

--- a/src/bot/util/templateParser.ts
+++ b/src/bot/util/templateParser.ts
@@ -1,0 +1,222 @@
+/* eslint @typescript-eslint/no-use-before-define: 0 */
+
+export interface Raw {
+	t: 'raw';
+	value: string;
+}
+
+export interface Interpolate {
+	t: 'interpolate';
+	alts: string[];
+	def: Template | null;
+}
+
+export type Template = (Raw | Interpolate)[];
+
+export class ParseError extends Error {
+	public readonly input: string;
+	public readonly position: number;
+
+	public constructor(message: string, input: string, position: number) {
+		super(message);
+
+		this.input = input;
+		this.position = position;
+	}
+
+	public formatted(): string {
+		const start = Math.max(this.lineBefore(), this.position - 10);
+		const end = Math.min(this.lineAfter(), this.position + 10);
+		const line = this.input.slice(start, end);
+		const offset = this.position - start;
+		return `${line}\n${'-'.repeat(offset)}^\n${this.message}`;
+	}
+
+	private lineBefore(): number {
+		const i = this.input.slice(0, this.position).lastIndexOf('\n');
+		return i === -1 ? 0 : i;
+	}
+
+	private lineAfter(): number {
+		const i = this.input.indexOf('\n', this.position);
+		return i === -1 ? this.input.length : i + this.position;
+	}
+}
+
+export function parse(input: string): Template {
+	return pTemplate({ input, position: 0 }, false);
+}
+
+/**
+ * EBNF:
+ *
+ * Template    = { Segment }
+ * Segment     = Interpolate | Raw
+ * Interpolate = "${" _ Alts [ Def ] "}"
+ * Alts        = Ident _ [{ "|" _ Ident _ }]
+ * Def         = "=" _'"' Template '"' _
+ * Raw         = Escaped | Character
+ * Escaped     = "\" any char
+ * Character   = any char
+ * Ident       = alphanumeric identifier
+ * _           = any amount of whitespace
+ */
+
+interface State {
+	input: string;
+	position: number;
+}
+
+function pTemplate(s: State, q: boolean): Template {
+	const segments: (string | Raw | Interpolate)[] = [];
+	while (s.position < s.input.length && (!q || !testString(s, '"'))) {
+		const seg = pSegment(s);
+		if (segments.length > 0) {
+			const prev = segments[segments.length - 1];
+			/**
+			 * To make things easier to use, we merge adjacent strings together,
+			 * instead of making pRaw return a Raw, since that allocates more objects.
+			 * Cases:
+			 * [string] + string = [string]
+			 * [raw]    + string = [raw]
+			 * [interp] + string = [interp, string]
+			 * [string] + interp = [raw, interp]
+			 * [raw]    + interp = [raw, interp]
+			 * [interp] + interp = [interp, interp]
+			 */
+			if (typeof seg === 'string') {
+				if (typeof prev === 'string') {
+					segments[segments.length - 1] += seg;
+				} else if (prev.t === 'raw') {
+					prev.value += seg;
+				} else {
+					segments.push(seg);
+				}
+			} else if (typeof prev === 'string') {
+				segments[segments.length - 1] = { t: 'raw', value: prev };
+				segments.push(seg);
+			} else {
+				segments.push(seg);
+			}
+		} else {
+			segments.push(seg);
+		}
+	}
+
+	if (segments.length > 0) {
+		const prev = segments[segments.length - 1];
+		if (typeof prev === 'string') {
+			segments[segments.length - 1] = { t: 'raw', value: prev };
+		}
+	}
+
+	if (s.position !== s.input.length) {
+		throw new ParseError('Not enough input', s.input, s.position);
+	}
+
+	return segments as Template;
+}
+
+function pSegment(s: State): string | Interpolate {
+	if (testString(s, '${')) {
+		return pInterpolate(s);
+	}
+
+	return pRaw(s);
+}
+
+function pInterpolate(s: State): Interpolate {
+	pString(s, '${');
+	p_(s);
+	const alts = pAlts(s);
+	let def = null;
+	if (testString(s, '=')) {
+		def = pDef(s);
+	}
+
+	pString(s, '}');
+	return { t: 'interpolate', alts, def };
+}
+
+function pAlts(s: State): string[] {
+	const idents = [];
+	idents.push(pIdent(s));
+	p_(s);
+	while (testString(s, '|')) {
+		pString(s, '|');
+		p_(s);
+		idents.push(pIdent(s));
+		p_(s);
+	}
+
+	return idents;
+}
+
+function pDef(s: State): Template {
+	pString(s, '=');
+	p_(s);
+	pString(s, '"');
+	const x = pTemplate(s, true);
+	pString(s, '"');
+	p_(s);
+	return x;
+}
+
+function pRaw(s: State): string {
+	return testString(s, '\\') ? pEscaped(s) : pCharacter(s);
+}
+
+function pEscaped(s: State): string {
+	const match = matchRegex(s, /^\\(.)/);
+	if (match === null) {
+		throw new ParseError('Expected an escape character', s.input, s.position);
+	}
+
+	s.position += match[0].length;
+	return match[1];
+}
+
+function pCharacter(s: State): string {
+	if (s.position >= s.input.length) {
+		throw new ParseError('Unexpected end of input', s.input, s.position);
+	}
+
+	s.position++;
+	return s.input[s.position - 1];
+}
+
+function pIdent(s: State): string {
+	const match = matchRegex(s, /^[A-Za-z0-9]+/);
+	if (match === null) {
+		throw new ParseError('Expected a valid identifier made of alphanumeric characters', s.input, s.position);
+	}
+
+	const ident = match[0];
+	s.position += ident.length;
+	return ident;
+}
+
+function p_(s: State): void {
+	const match = matchRegex(s, /^\s*/);
+	s.position += match![0].length;
+}
+
+function pString(s: State, x: string): void {
+	if (testString(s, x)) {
+		s.position += x.length;
+	} else {
+		throw new ParseError(
+			`Expected token ${x} but got ${s.input[s.position] || 'unexpected end of input'}`,
+			s.input,
+			s.position,
+		);
+	}
+}
+
+function testString(s: State, x: string): boolean {
+	return s.input.startsWith(x, s.position);
+}
+
+function matchRegex(s: State, r: RegExp): RegExpMatchArray | null {
+	return r.exec(s.input.slice(s.position));
+}

--- a/src/bot/util/templateParser.ts
+++ b/src/bot/util/templateParser.ts
@@ -24,7 +24,7 @@ export class ParseError extends Error {
 		this.position = position;
 	}
 
-	public formatted(): string {
+	public formatted() {
 		const start = Math.max(this.lineBefore(), this.position - 10);
 		const end = Math.min(this.lineAfter(), this.position + 10);
 		const line = this.input.slice(start, end);
@@ -32,18 +32,18 @@ export class ParseError extends Error {
 		return `${line}\n${'-'.repeat(offset)}^\n${this.message}`;
 	}
 
-	private lineBefore(): number {
+	private lineBefore() {
 		const i = this.input.slice(0, this.position).lastIndexOf('\n');
 		return i === -1 ? 0 : i;
 	}
 
-	private lineAfter(): number {
+	private lineAfter() {
 		const i = this.input.indexOf('\n', this.position);
 		return i === -1 ? this.input.length : i + this.position;
 	}
 }
 
-export function parse(input: string): Template {
+export function parse(input: string) {
 	return pTemplate({ input, position: 0 }, false);
 }
 
@@ -67,7 +67,7 @@ interface State {
 	position: number;
 }
 
-function pTemplate(s: State, q: boolean): Template {
+function pTemplate(s: State, q: boolean) {
 	const segments: (string | Raw | Interpolate)[] = [];
 	while (s.position < s.input.length && (!q || !testString(s, '"'))) {
 		const seg = pSegment(s);
@@ -117,7 +117,7 @@ function pTemplate(s: State, q: boolean): Template {
 	return segments as Template;
 }
 
-function pSegment(s: State): string | Interpolate {
+function pSegment(s: State) {
 	if (testString(s, '${')) {
 		return pInterpolate(s);
 	}
@@ -138,7 +138,7 @@ function pInterpolate(s: State): Interpolate {
 	return { t: 'interpolate', alts, def };
 }
 
-function pAlts(s: State): string[] {
+function pAlts(s: State) {
 	const idents = [];
 	idents.push(pIdent(s));
 	p_(s);
@@ -152,7 +152,7 @@ function pAlts(s: State): string[] {
 	return idents;
 }
 
-function pDef(s: State): Template {
+function pDef(s: State) {
 	pString(s, '=');
 	p_(s);
 	pString(s, '"');
@@ -162,11 +162,11 @@ function pDef(s: State): Template {
 	return x;
 }
 
-function pRaw(s: State): string {
+function pRaw(s: State) {
 	return testString(s, '\\') ? pEscaped(s) : pCharacter(s);
 }
 
-function pEscaped(s: State): string {
+function pEscaped(s: State) {
 	const match = matchRegex(s, /^\\(.)/);
 	if (match === null) {
 		throw new ParseError('Expected an escape character', s.input, s.position);
@@ -176,7 +176,7 @@ function pEscaped(s: State): string {
 	return match[1];
 }
 
-function pCharacter(s: State): string {
+function pCharacter(s: State) {
 	if (s.position >= s.input.length) {
 		throw new ParseError('Unexpected end of input', s.input, s.position);
 	}
@@ -185,7 +185,7 @@ function pCharacter(s: State): string {
 	return s.input[s.position - 1];
 }
 
-function pIdent(s: State): string {
+function pIdent(s: State) {
 	const match = matchRegex(s, /^[A-Za-z0-9]+/);
 	if (match === null) {
 		throw new ParseError('Expected a valid identifier made of alphanumeric characters', s.input, s.position);
@@ -196,12 +196,12 @@ function pIdent(s: State): string {
 	return ident;
 }
 
-function p_(s: State): void {
+function p_(s: State) {
 	const match = matchRegex(s, /^\s*/);
 	s.position += match![0].length;
 }
 
-function pString(s: State, x: string): void {
+function pString(s: State, x: string) {
 	if (testString(s, x)) {
 		s.position += x.length;
 	} else {
@@ -213,10 +213,10 @@ function pString(s: State, x: string): void {
 	}
 }
 
-function testString(s: State, x: string): boolean {
+function testString(s: State, x: string) {
 	return s.input.startsWith(x, s.position);
 }
 
-function matchRegex(s: State, r: RegExp): RegExpMatchArray | null {
+function matchRegex(s: State, r: RegExp) {
 	return r.exec(s.input.slice(s.position));
 }


### PR DESCRIPTION
This adds the ability to do templating for tags. The proposed syntax for interpolation is the following:
- `${ var }` interpolates the preset value of `var`, this can be like `author` or `channel`.
- ~~`${ 0 }` interpolates an argument variable, the idea is that you can do `?tag | arg0 arg1 etc`.~~
- `${ x | y | z }` interpolates the first existing variable.
- `${ x | y | z = "default" }` interpolates the first variable that exists, or the default. You can nest templates inside the default string.

Of course, you can use any combination of these features.  
Valid identifiers are `/^[A-Za-z0-9]+$/`, but we can add other characters if it looks nice.  
You can escape with a `\` to insert a literal `${`, `"`, or `\`.  
As for the commands, we should have a flag that switches to templating mode and stores said flag in the database, to keep backwards compatibility. ~~That, or just use this as the default and break everything.~~

TODO:
- [X] Parser
- [X] Commands
- [ ] Database
