### PR TITLE
feat: additional log information

### DIFF
--- a/src/bot/listeners/client/guildLog/messageDelete.ts
+++ b/src/bot/listeners/client/guildLog/messageDelete.ts
@@ -24,7 +24,8 @@ export default class MessageDeleteGuildLogListener extends Listener {
 				.setColor(0x824aee)
 				.setAuthor(`${message.author.tag} (${message.author.id})`, message.author.displayAvatarURL())
 				.addField('❯ Channel', message.channel)
-				.addField('❯ Message', `${message.content.substring(0, 1020)}`);
+				.addField('❯ Message', `${message.content.substring(0, 1020)}`)
+				.addField('❯ Message', `[Jump To](${message.url})`, true);
 			if (attachment) embed.addField('❯ Attachment(s)', attachment.url);
 			embed.setTimestamp(new Date());
 			embed.setFooter('Deleted');

--- a/src/bot/listeners/client/guildLog/messageDeleteBulk.ts
+++ b/src/bot/listeners/client/guildLog/messageDeleteBulk.ts
@@ -34,6 +34,7 @@ export default class MessageDeleteBulkGuildLogListener extends Listener {
 					`${messages.first()!.author.tag} (${messages.first()!.author.id})`,
 					messages.first()!.author.displayAvatarURL(),
 				)
+				.addField('❯ Channel', messages.first()!.channel)
 				.addField('❯ Logs', 'See attachment file for full logs (possibly above this embed)')
 				.setTimestamp(new Date())
 				.setFooter('Bulk Deleted');


### PR DESCRIPTION
* add jumplink to messageDelete (while the message might be deleted already this still allows to jump to the closest message in said channel, which can be important to find the context of the deleted message)
* add channel to messageDeleteBulk (bulkDelete emits once per channel, thus the channel can be provided as information based on the first - or really any - message in the collection)

Format should be consistent with other events.