### PR TITLE
feat(docs): early abandon

### DIFF
--- a/src/bot/commands/doc/docs.ts
+++ b/src/bot/commands/doc/docs.ts
@@ -72,6 +72,9 @@ export default class DocsCommand extends Command {
 		const q = query.split(' ');
 		const docs = this.client.settings.get(guild, SETTINGS.DEFAULT_DOCS, 'stable');
 		let source = SOURCES.includes(q.slice(-1)[0]) ? q.pop()! : docs;
+		if (!q.length) {
+			return message.util?.reply(MESSAGES.COMMANDS.DOCS.DOCS.FAILURE);
+		}
 		if (source === '11.5-dev') {
 			source = `https://raw.githubusercontent.com/discordjs/discord.js/docs/${source}.json`;
 		}

--- a/src/bot/commands/doc/docs.ts
+++ b/src/bot/commands/doc/docs.ts
@@ -72,14 +72,8 @@ export default class DocsCommand extends Command {
 		const q = query.split(' ');
 		const docs = this.client.settings.get(guild, SETTINGS.DEFAULT_DOCS, 'stable');
 		let source = SOURCES.includes(q.slice(-1)[0]) ? q.pop()! : docs;
-		if (!q.length) {
-			return message.util?.reply(MESSAGES.COMMANDS.DOCS.DOCS.FAILURE);
-		}
 		if (source === '11.5-dev') {
 			source = `https://raw.githubusercontent.com/discordjs/discord.js/docs/${source}.json`;
-		}
-		if (source === 'collection') {
-			source = `https://raw.githubusercontent.com/discordjs/${source}/docs/master.json`;
 		}
 		const queryString = qs.stringify({ src: source, q: q.join(' '), force, includePrivate });
 		const res = await fetch(`https://djsdocs.sorta.moe/v2/embed?${queryString}`);

--- a/src/bot/commands/doc/docs.ts
+++ b/src/bot/commands/doc/docs.ts
@@ -72,8 +72,14 @@ export default class DocsCommand extends Command {
 		const q = query.split(' ');
 		const docs = this.client.settings.get(guild, SETTINGS.DEFAULT_DOCS, 'stable');
 		let source = SOURCES.includes(q.slice(-1)[0]) ? q.pop()! : docs;
+		if (!q.length) {
+			return message.util?.reply(MESSAGES.COMMANDS.DOCS.DOCS.FAILURE);
+		}
 		if (source === '11.5-dev') {
 			source = `https://raw.githubusercontent.com/discordjs/discord.js/docs/${source}.json`;
+		}
+		if (source === 'collection') {
+			source = `https://raw.githubusercontent.com/discordjs/${source}/docs/master.json`;
 		}
 		const queryString = qs.stringify({ src: source, q: q.join(' '), force, includePrivate });
 		const res = await fetch(`https://djsdocs.sorta.moe/v2/embed?${queryString}`);


### PR DESCRIPTION
* early abandon if no query is specified

```js
if (!embed) {
    return message.util?.reply(MESSAGES.COMMANDS.DOCS.DOCS.FAILURE);
}
```

Does not suffice as check, as the error object resolved here if the query is missing is interpreted as embed object and sent as empty box;

While this could be adapted to handle that case, an easier way is to insert the proposed check here, if the query - after slicing the source from it - is empty, the user just provided a resource but no query to go with it `?docs master`, `?docs 11.5-dev` etc.

~~* collection source override~~

~~Add the ability to query the Collection API via the docs command
Kept it as replacement string for easier adaption, should discord.js launch other side projects we might need documentation for one day, in which case the condition in line 81 can be adapted.~~

~~Should we ever need to discern tags from the Collection documentation a different argument syntax is advisable.~~