### PR TITLE
fix: Update the help command of docs

### DIFF
--- a/src/bot/commands/doc/docs.ts
+++ b/src/bot/commands/doc/docs.ts
@@ -21,7 +21,7 @@ export default class DocsCommand extends Command {
 			description: {
 				content: MESSAGES.COMMANDS.DOCS.DOCS.DESCRIPTION,
 				usage: '<query>',
-				examples: ['TextChannel', 'Client', 'ClientUser#setActivity master'],
+				examples: ['TextChannel', 'Client', 'ClientUser#setActivity --src=master'],
 			},
 			category: 'doc',
 			clientPermissions: [Permissions.FLAGS.EMBED_LINKS],


### PR DESCRIPTION
This PR fixes the help command examples of the command, where the correct usage to access another branch other than stable is ``--src=branch``.