### PR TITLE
refactor(docs): replace 11.5-dev source with v11

### DIFF
--- a/src/bot/commands/doc/docs.ts
+++ b/src/bot/commands/doc/docs.ts
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 import * as qs from 'querystring';
 import { MESSAGES, SETTINGS } from '../../util/constants';
 
-const SOURCES = ['stable', 'master', 'rpc', 'commando', 'akairo', 'akairo-master', '11.5-dev', 'collection'];
+const SOURCES = ['stable', 'master', 'rpc', 'commando', 'akairo', 'akairo-master', 'v11', 'collection'];
 
 interface DocsCommandArguments {
 	defaultDocs: string;
@@ -79,7 +79,7 @@ export default class DocsCommand extends Command {
 		if (!SOURCES.includes(source)) {
 			source = this.client.settings.get(guild, SETTINGS.DEFAULT_DOCS, 'stable');
 		}
-		if (source === '11.5-dev') {
+		if (source === 'v11') {
 			source = `https://raw.githubusercontent.com/discordjs/discord.js/docs/${source}.json`;
 		}
 		const queryString = qs.stringify({ src: source, q: q.join(' '), force, includePrivate });


### PR DESCRIPTION
This PR removes the `11.5-dev` docs source from the `docs` command and adds `v11` as replacement.
The `11.5-dev` branch is no longer and should not be referenced any more and `v11` would be the """current""" counterpart.