### PR TITLE
feat(lockdown): deny ADD_REACTIONS permission

### DIFF
--- a/src/bot/structures/LockdownScheduler.ts
+++ b/src/bot/structures/LockdownScheduler.ts
@@ -75,8 +75,8 @@ export default class LockdownScheduler {
 		await chan.updateOverwrite(
 			lock.guild,
 			{
-				SEND_MESSAGES: true,
-				ADD_REACTIONS: true,
+				SEND_MESSAGES: null,
+				ADD_REACTIONS: null,
 			},
 			`Lockdown removed based on duration.`,
 		);

--- a/src/bot/structures/LockdownScheduler.ts
+++ b/src/bot/structures/LockdownScheduler.ts
@@ -38,6 +38,7 @@ export default class LockdownScheduler {
 			lockdown.guild,
 			{
 				SEND_MESSAGES: false,
+				ADD_REACTIONS: false,
 			},
 			`Lockdown for ${ms(duration)} by ${author.tag}`,
 		);
@@ -75,6 +76,7 @@ export default class LockdownScheduler {
 			lock.guild,
 			{
 				SEND_MESSAGES: true,
+				ADD_REACTIONS: true,
 			},
 			`Lockdown removed based on duration.`,
 		);


### PR DESCRIPTION
This PR also denies `ADD_REACTIONS` when locking down a channel using the `lockdown` command.

Since the first thing people do once they notice that they can no longer send messages is spamming reactions, this would be a good way to counter that.

---

Is it intended to explicitly set the permissions to `true` on the overwrite after lifting the lockdown?
I'd assume the everyone role would have that (or these) permission(s) per default and setting it to `inherit` / `null` could be preferred.