### PR TITLE
fix(info.channel): missing colon

### DIFF
--- a/src/bot/commands/info/channel.ts
+++ b/src/bot/commands/info/channel.ts
@@ -37,7 +37,7 @@ export default class ChannelInfoCommand extends Command {
 				'❯ Info',
 				stripIndents`
 				• Type: ${channel.type}
-				• Topic ${channel.topic || 'None'}
+				• Topic: ${channel.topic || 'None'}
 				• NSFW: ${Boolean(channel.nsfw)}
 				• Creation Date: ${moment.utc(channel.createdAt).format('YYYY/MM/DD hh:mm:ss')}
 			`,


### PR DESCRIPTION
There's a missing colon in the `channel` command, so this pull request puts it in its place!