### PR TITLE
refactor(db): rewrite migrations for cases and settings

### DIFF
--- a/hasura/migrations/1586479065565_next/down.sql
+++ b/hasura/migrations/1586479065565_next/down.sql
@@ -5,7 +5,41 @@ alter table tags rename guild_id to guild;
 
 -- SETTINGS
 
-alter table settings rename guild_id to guild;
+create table settings (
+	guild text,
+	settings jsonb default '{}'::json
+);
+
+alter table settings
+	add constraint settings_pkey primary key (guild)
+;
+
+insert into settings (
+	select guild_id as guild,
+		to_jsonb(
+			(
+				select d
+				from (
+					select prefix as "PREFIX",
+						mod_log_channel_id as "MOD_LOG",
+						mod_role_id as "MOD_ROLE",
+						guild_log_id as "GUILD_LOG",
+						member_log_id as "MEMBER_LOG",
+						mute_role_id as "MUTE_ROLE",
+						role_state as "ROLE_STATE",
+						moderation as "MODERATION",
+						json_build_object(
+							'TAG', tag_role_id,
+							'EMBED', embed_role_id,
+							'EMOJI', emoji_role_id,
+							'REACTION', reaction_role_id
+						) as "RESTRICT_ROLES"
+				) d)
+		) as settings
+	from guild_settings;
+);
+
+drop table guild_settings;
 
 -- ROLE STATES
 

--- a/hasura/migrations/1586479065565_next/up.sql
+++ b/hasura/migrations/1586479065565_next/up.sql
@@ -56,6 +56,20 @@ alter table cases
 	add constraint cases_pkey primary key (guild_id, case_id)
 ;
 
+update cases set
+	action = case
+		when action = 1 then 5
+		when action = 2 then 6
+		when action = 3 then 4
+		when action = 4 then 3
+		when action = 5 then 0
+		when action = 6 then 0
+		when action = 7 then 0
+		when action = 8 then 0
+		when action = 9 then 2
+		when action = 10 then 0
+	end;
+
 -- LOCKDOWNS
 
 alter table lockdowns rename channel to channel_id;
@@ -81,9 +95,46 @@ alter table role_states
 	add constraint role_states_pkey primary key (guild_id, member_id)
 ;
 
--- SETTINGS
+-- GUILD_SETTINGS
 
-alter table settings rename guild to guild_id;
+create table guild_settings (
+	guild_id text,
+	prefix text default '?',
+	mod_log_channel_id text,
+	mod_role_id text,
+	guild_log_id text,
+	member_log_id text,
+	mute_role_id text,
+	tag_role_id text,
+	embed_role_id text,
+	emoji_role_id text,
+	reaction_role_id text,
+	role_state boolean default false,
+	moderation boolean default false
+);
+
+alter table guild_settings
+	add constraint guild_settings_pkey primary key (guild_id)
+;
+
+insert into guild_settings (
+	select guild as guild_id,
+		coalesce((settings ->> 'PREFIX')::text, '?') as prefix,
+		(settings ->> 'MOD_LOG')::text as mod_log_channel_id,
+		(settings ->> 'MOD_ROLE')::text as mod_role_id,
+		(settings ->> 'GUILD_LOG')::text as guild_log_id,
+		(settings -> 'MEMBER_LOG' ->> 'ID')::text as member_log_id,
+		(settings ->> 'MUTE_ROLE')::text as mute_role_id,
+		(settings -> 'RESTRICT_ROLES' ->> 'TAG')::text as tag_role_id,
+		(settings -> 'RESTRICT_ROLES' ->> 'EMBED')::text as embed_role_id,
+		(settings -> 'RESTRICT_ROLES' ->> 'EMOJI')::text as emoji_role_id,
+		(settings -> 'RESTRICT_ROLES' ->> 'REACTION')::text as reaction_role_id,
+		coalesce((settings ->> 'ROLE_STATE')::boolean, false) as role_state,
+		coalesce((settings ->> 'MODERATION')::boolean, false) as moderation
+	from settings
+);
+
+drop table settings;
 
 -- TAGS
 

--- a/hasura/optional_migrations/1586479065565_next/down.sql
+++ b/hasura/optional_migrations/1586479065565_next/down.sql
@@ -10,11 +10,41 @@ alter table tags rename guild_id to guild;
 
 -- SETTINGS
 
+create table settings (
+	guild text,
+	settings jsonb default '{}'::json
+);
+
 alter table settings
-	alter guild_id set data type text
+	add constraint settings_pkey primary key (guild)
 ;
 
-alter table settings rename guild_id to guild;
+insert into settings (
+	select guild_id as guild,
+		to_jsonb(
+			(
+				select d
+				from (
+					select prefix as "PREFIX",
+						mod_log_channel_id as "MOD_LOG",
+						mod_role_id as "MOD_ROLE",
+						guild_log_id as "GUILD_LOG",
+						member_log_id as "MEMBER_LOG",
+						mute_role_id as "MUTE_ROLE",
+						role_state as "ROLE_STATE",
+						moderation as "MODERATION",
+						json_build_object(
+							'TAG', tag_role_id,
+							'EMBED', embed_role_id,
+							'EMOJI', emoji_role_id,
+							'REACTION', reaction_role_id
+						) as "RESTRICT_ROLES"
+				) d)
+		) as settings
+	from guild_settings;
+);
+
+drop table guild_settings;
 
 -- ROLE STATES
 

--- a/packages/api/src/managers/CaseLogManager.test.ts
+++ b/packages/api/src/managers/CaseLogManager.test.ts
@@ -114,11 +114,11 @@ test('creates basic kick case', async () => {
 		1,
 		[
 			`
-			select settings ->> `,
+			select `,
 			` as value
-			from settings
+			from guild_settings
 			where guild_id = `,
-			`;`,
+			'',
 		],
 		SettingsKeys.MOD_LOG_CHANNEL_ID,
 		guildId,
@@ -362,11 +362,11 @@ test('creates ban without a reason', async () => {
 		2,
 		[
 			`
-			select settings ->> `,
+			select `,
 			` as value
-			from settings
+			from guild_settings
 			where guild_id = `,
-			`;`,
+			'',
 		],
 		SettingsKeys.PREFIX,
 		guildId,

--- a/packages/api/src/managers/CaseManager.test.ts
+++ b/packages/api/src/managers/CaseManager.test.ts
@@ -116,7 +116,7 @@ test('creates role case', async () => {
 	expect(saved).toBe(case_);
 	expect(saved.caseId).toBe(1);
 	expect(mockedRest.put).toHaveBeenCalledTimes(1);
-	expect(mockedRest.put).toHaveBeenCalledWith('/guilds/1234/members/3456/roles/4567', {}, { reason: 'foo' });
+	expect(mockedRest.put).toHaveBeenCalledWith('/guilds/1234/members/3456/roles/4567', {}, { reason: 'Case #0' });
 	expect(mockedPostgres).toHaveBeenCalledTimes(1);
 	expect(mockedPostgres).toHaveBeenCalledWith(...generateSQLResult(case_));
 });
@@ -138,7 +138,7 @@ test('creates un-role case', async () => {
 	expect(saved).toBe(case_);
 	expect(saved.caseId).toBe(1);
 	expect(mockedRest.delete).toHaveBeenCalledTimes(1);
-	expect(mockedRest.delete).toHaveBeenCalledWith('/guilds/1234/members/3456/roles/4567', { reason: 'foo' });
+	expect(mockedRest.delete).toHaveBeenCalledWith('/guilds/1234/members/3456/roles/4567', { reason: 'Case #0' });
 	expect(mockedPostgres).toHaveBeenCalledTimes(1);
 	expect(mockedPostgres).toHaveBeenCalledWith(...generateSQLResult(case_));
 });
@@ -180,7 +180,7 @@ test('creates kick case with context', async () => {
 	expect(saved).toBe(case_);
 	expect(saved.caseId).toBe(1);
 	expect(mockedRest.delete).toHaveBeenCalledTimes(1);
-	expect(mockedRest.delete).toHaveBeenCalledWith('/guilds/1234/members/3456', { reason: 'foo' });
+	expect(mockedRest.delete).toHaveBeenCalledWith('/guilds/1234/members/3456', { reason: 'Case #0' });
 	expect(mockedPostgres).toHaveBeenCalledTimes(1);
 	expect(mockedPostgres).toHaveBeenCalledWith(...generateSQLResult(case_));
 });
@@ -202,11 +202,11 @@ test('creates softban with delete message days', async () => {
 	expect(saved).toBe(case_);
 	expect(saved.caseId).toBe(1);
 	expect(mockedRest.put).toHaveBeenCalledTimes(1);
-	expect(mockedRest.put).toHaveBeenCalledWith('/guilds/1234/bans/3456?delete-message-days=3&reason=foo', {
-		reason: 'foo',
+	expect(mockedRest.put).toHaveBeenCalledWith('/guilds/1234/bans/3456?delete-message-days=3&reason=Case+%230', {
+		reason: 'Case #0',
 	});
 	expect(mockedRest.delete).toHaveBeenCalledTimes(1);
-	expect(mockedRest.delete).toHaveBeenCalledWith('/guilds/1234/bans/3456', { reason: 'Softban: foo' });
+	expect(mockedRest.delete).toHaveBeenCalledWith('/guilds/1234/bans/3456', { reason: 'Case #0' });
 	expect(mockedPostgres).toHaveBeenCalledTimes(1);
 	expect(mockedPostgres).toHaveBeenCalledWith(...generateSQLResult(case_));
 });
@@ -229,8 +229,8 @@ test('creates ban with expiration & default delete message days', async () => {
 	expect(saved).toBe(case_);
 	expect(saved.caseId).toBe(1);
 	expect(mockedRest.put).toHaveBeenCalledTimes(1);
-	expect(mockedRest.put).toHaveBeenCalledWith('/guilds/1234/bans/3456?delete-message-days=1&reason=foo', {
-		reason: 'foo',
+	expect(mockedRest.put).toHaveBeenCalledWith('/guilds/1234/bans/3456?delete-message-days=1&reason=Case+%230', {
+		reason: 'Case #0',
 	});
 	expect(mockedPostgres).toHaveBeenCalledTimes(1);
 	expect(mockedPostgres).toHaveBeenCalledWith(...generateSQLResult(case_));
@@ -254,7 +254,7 @@ test('creates unban case', async () => {
 	expect(saved).toBe(case_);
 	expect(saved.caseId).toBe(1);
 	expect(mockedRest.delete).toHaveBeenCalledTimes(1);
-	expect(mockedRest.delete).toHaveBeenCalledWith('/guilds/1234/bans/3456', { reason: 'foo' });
+	expect(mockedRest.delete).toHaveBeenCalledWith('/guilds/1234/bans/3456', { reason: 'Case #0' });
 	expect(mockedPostgres).toHaveBeenCalledTimes(1);
 	expect(mockedPostgres).toHaveBeenCalledWith(...generateSQLResult(case_));
 });

--- a/packages/api/src/managers/CaseManager.ts
+++ b/packages/api/src/managers/CaseManager.ts
@@ -56,7 +56,7 @@ export default class CaseManager {
 	) {}
 
 	public async create(case_: Case) {
-		const requestOptions = { reason: case_.reason };
+		const requestOptions = { reason: `Case #${case_.caseId}` };
 		switch (case_.action) {
 			case CaseAction.ROLE:
 				await this.rest.put(
@@ -79,19 +79,17 @@ export default class CaseManager {
 			case CaseAction.SOFTBAN: {
 				const params = new URLSearchParams({
 					'delete-message-days': case_.deleteMessageDays?.toString() ?? '1',
-					reason: case_.reason,
+					reason: requestOptions.reason,
 				});
 
 				await this.rest.put(`/guilds/${case_.guildId}/bans/${case_.targetId}?${params.toString()}`, requestOptions);
-				await this.rest.delete(`/guilds/${case_.guildId}/bans/${case_.targetId}`, {
-					reason: `Softban: ${case_.reason}`,
-				});
+				await this.rest.delete(`/guilds/${case_.guildId}/bans/${case_.targetId}`, requestOptions);
 				break;
 			}
 			case CaseAction.BAN: {
 				const params = new URLSearchParams({
 					'delete-message-days': case_.deleteMessageDays?.toString() ?? '1',
-					reason: case_.reason,
+					reason: requestOptions.reason,
 				});
 
 				await this.rest.put(`/guilds/${case_.guildId}/bans/${case_.targetId}?${params.toString()}`, requestOptions);

--- a/packages/api/src/managers/SettingsManager.test.ts
+++ b/packages/api/src/managers/SettingsManager.test.ts
@@ -26,11 +26,11 @@ test('gets settings', async () => {
 	expect(mockedPostgres).toHaveBeenCalledWith(
 		[
 			`
-			select settings ->> `,
+			select `,
 			` as value
-			from settings
+			from guild_settings
 			where guild_id = `,
-			`;`,
+			'',
 		],
 		'foo',
 		'1234',
@@ -48,11 +48,11 @@ test('gets missing setting', async () => {
 	expect(mockedPostgres).toHaveBeenCalledWith(
 		[
 			`
-			select settings ->> `,
+			select `,
 			` as value
-			from settings
+			from guild_settings
 			where guild_id = `,
-			`;`,
+			'',
 		],
 		'foo',
 		'1234',

--- a/packages/api/src/managers/SettingsManager.ts
+++ b/packages/api/src/managers/SettingsManager.ts
@@ -15,10 +15,10 @@ export default class SettingsManager {
 	) {}
 
 	public async get(guildId: string, prop: string): Promise<string | null> {
-		const [data] = await this.sql`
-			select settings ->> ${prop} as value
-			from settings
-			where guild_id = ${guildId};`;
+		const [data]: any = await this.sql`
+			select ${prop} as value
+			from guild_settings
+			where guild_id = ${guildId}`;
 
 		return data?.value ?? null;
 	}

--- a/packages/parser/bin/index.ts
+++ b/packages/parser/bin/index.ts
@@ -17,10 +17,9 @@ void (async () => {
 		[Message, AmqpResponseOptions]
 	>) {
 		ack();
-		const [data] = (await sql`select settings ->> 'PREFIX' as prefix
-			from settings
-			where guild_id = ${message.guild_id ?? null}
-				is not null;`) as [{ prefix: string | null }];
+		const [data] = (await sql`select prefix
+			from guild_settings
+			where guild_id = ${message.guild_id ?? null};`) as [{ prefix: string | null }];
 		const prefix = data.prefix ?? '?';
 		const lexer = new Lexer(message.content).setQuotes([
 			['"', '"'],


### PR DESCRIPTION
There is deliberately no migration for actions in the `down.sql` because it's a destructive up migration that simply cannot be reverted without keeping state somewhere. This is a non-issue for us though.

This also fixes the reason in the audit log to be somewhat consistent with the current implementation:
![image](https://user-images.githubusercontent.com/20760160/87235693-e1ff9180-c3de-11ea-835e-2eeb2d70739d.png)

It would be odd to have a very long reason in there which gets cut off by Discord putting an ellipses there, so I decided to opt for just the case itself.