### PR TITLE
feat: log message id in guild log

### DIFF
--- a/src/events/guild-log/messageDelete.ts
+++ b/src/events/guild-log/messageDelete.ts
@@ -70,7 +70,7 @@ export default class implements Event {
 							? message.content
 							: i18next.t('log.guild_log.message_deleted.no_content', { lng: locale })
 					}`,
-					footer: i18next.t('log.guild_log.message_deleted.footer', { id: message.id, lng: locale }),
+					footer: { text: message.id },
 					timestamp: new Date().toISOString(),
 				});
 

--- a/src/events/guild-log/messageUpdate.ts
+++ b/src/events/guild-log/messageUpdate.ts
@@ -109,7 +109,7 @@ export default class implements Event {
 						color: 6057215,
 						title: i18next.t('log.guild_log.message_updated.title', { lng: locale }),
 						description,
-						footer: i18next.t('log.guild_log.message_updated.footer', { id: newMessage.id, lng: locale }),
+						footer: { text: newMessage.id },
 						timestamp: new Date().toISOString(),
 					},
 					{


### PR DESCRIPTION
* Adds the message's ID to the embed footer in message update/delete logs for searchability

![Showcase](https://i.imgur.com/gqvP5Gw.png)